### PR TITLE
feat(phase9): W9-2a — Gecko legacy port (pcap-analyzer.py + fail2ban, closes #50)

### DIFF
--- a/iso/config/hooks/live/0700-orionx-setup.hook.chroot
+++ b/iso/config/hooks/live/0700-orionx-setup.hook.chroot
@@ -61,6 +61,11 @@ declare -A SCRIPT_MAP=(
     ["toggle-theme.sh"]="/opt/orionx/scripts/toggle-theme.sh"
     ["run-lynis.sh"]="/opt/orionx/scripts/run-lynis.sh"
     ["download-samples.sh"]="/opt/orionx/scripts/download-samples.sh"
+    # W9-2a: pcap-analyzer.py — modernized STA PCAP analysis tool (DEC-PHASE9-017)
+    # Replaces gecko/bin/analyze-pcap.sh with a clean Python 3 tool wrapping
+    # tshark (already installed) + optional tcpdump. CLI-only; no .desktop
+    # launcher here — that is deferred to the W9-2 Control Center slice.
+    ["pcap-analyzer.py"]="/opt/orionx/scripts/pcap-analyzer.py"
 )
 
 for name in "${!SCRIPT_MAP[@]}"; do
@@ -160,6 +165,7 @@ Quick start:
   orionx-mesh       — WireGuard P2P mesh management
   setup-matrix.sh   — Matrix/Synapse setup
   artifact-analyzer.py — Forensic artifact analysis
+  pcap-analyzer.py  — Structured PCAP traffic analysis (STA)
   storyboard-gen.py — Generate storyboards
 
 Type 'orionx-help' for the full command reference.
@@ -179,6 +185,7 @@ orionx-help() {
     echo "  setup-wireguard.sh   WireGuard interface setup"
     echo "  setup-matrix.sh      Matrix/Synapse server setup"
     echo "  artifact-analyzer.py Forensic artifact analysis"
+    echo "  pcap-analyzer.py     Structured PCAP traffic analysis (STA, Bejtlich method)"
     echo "  storyboard-gen.py    Intelligence storyboard generation"
     echo "  toggle-theme.sh      Toggle light/dark desktop theme"
     echo "  run-lynis.sh         Run Lynis security audit"

--- a/iso/config/package-lists/orionx.list.chroot
+++ b/iso/config/package-lists/orionx.list.chroot
@@ -103,6 +103,18 @@ aircrack-ng
 chntpw
 clamav
 cryptsetup
+# fail2ban — SSH brute-force defense; modernized replacement for the obsolete
+# denyhosts concept in gecko/bin/start-denyhosts.sh. The package postinst
+# enables fail2ban-server.service via dh_installsystemd (same pattern as
+# network-manager in W9-1 DEC-PHASE9-004 — no custom systemd unit needed).
+# @decision DEC-PHASE9-018
+# @title fail2ban replaces gecko/bin/start-denyhosts.sh
+# @status accepted
+# @rationale denyhosts is unmaintained and not in Debian Bullseye. fail2ban
+#   provides equivalent SSH brute-force defense with active Debian packaging
+#   and systemd integration. Daemon is enabled by the package's own postinst
+#   (dh_installsystemd); no custom hook or unit file required (same as NM).
+fail2ban
 hashcat
 hydra
 john

--- a/scripts/pcap-analyzer.py
+++ b/scripts/pcap-analyzer.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""
+Orion-X Phoenix Edition — PCAP Analyzer
+========================================
+Structured Traffic Analysis (STA) of packet captures using tshark (primary)
+and tcpdump (supplementary), following the Bejtlich methodology.
+
+Usage examples:
+    pcap-analyzer.py capture.pcap
+    pcap-analyzer.py capture.pcap --output-dir ~/Analysis/incident-2026/
+    pcap-analyzer.py capture.pcap --quick
+    pcap-analyzer.py capture.pcap --report ~/reports/summary.txt
+
+Analysis phases (Bejtlich STA pattern):
+    Phase 1: Capture metadata     — packet count, time range, byte totals
+    Phase 2: Protocol hierarchy   — protocol distribution via io,phs
+    Phase 3: Conversations        — top IP and TCP talkers (conv,ip / conv,tcp)
+    Phase 4: Endpoints            — IP endpoint table (endpoints,ip)
+    Phase 5: App-layer overview   — HTTP, DNS, TLS statistics (skipped with --quick)
+    Phase 6: Readable summary     — tcpdump first-200 packet human-readable dump
+                                    (only when tcpdump is present on PATH)
+
+Outputs:
+    <output-dir>/
+        01-metadata.txt         — Phase 1 tshark io,stat,0
+        02-protocols.txt        — Phase 2 protocol hierarchy
+        03-conversations-ip.txt — Phase 3 IP conversations
+        03-conversations-tcp.txt— Phase 3 TCP conversations
+        04-endpoints-ip.txt     — Phase 4 IP endpoints
+        05-http.txt             — Phase 5 HTTP stats (omitted with --quick)
+        05-dns.txt              — Phase 5 DNS stats  (omitted with --quick)
+        05-tls.txt              — Phase 5 TLS stats  (omitted with --quick)
+        06-tcpdump-head.txt     — Phase 6 tcpdump readable (when available)
+        summary.txt             — Consolidated overview of all phases
+    Each file begins with a chain-of-custody header (pcap name, SHA-256,
+    analysis timestamp, hostname, tool versions).
+
+Exit codes:
+    0  — analysis complete (all required phases ran)
+    1  — input validation failure (file not found, not readable)
+    2  — required tool missing (tshark not on PATH)
+
+@decision DEC-PHASE9-017
+@title W9-2a gecko-legacy port: pcap-analyzer.py — modernized STA tool
+@status accepted
+@rationale The gecko/bin/analyze-pcap.sh (circa 2009–2010) ran argus, dsniff,
+    chaosreader, sancp, snort, ettercap, ngrep, p0f, and many other tools that
+    are either obsolete, out-of-package, or require complex system-level config
+    that does not belong in a live ISO. The Orion-X ISO already ships tshark
+    (wireshark package) and tcpdump — both are first-class PCAP analysis tools.
+    This rewrite delivers the same operator value (structured per-phase output,
+    summary table, chain-of-custody header) using only what is already present
+    on the live system, with a clean Python argparse CLI instead of an
+    interactive bash prompt. No shell-idiom literal port; this is a clean
+    Python 3 tool using stdlib only (no extra pip deps). The gecko shell script
+    is reference-only and is NOT staged into the ISO.
+"""
+
+import argparse
+import datetime
+import hashlib
+import os
+import pathlib
+import shutil
+import socket
+import subprocess
+import sys
+import textwrap
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TOOL_TSHARK = "tshark"
+_TOOL_TCPDUMP = "tcpdump"
+
+# Phases emitted by run_phases(); each entry: (filename, label, args)
+# args is a list of tshark arguments (after -r <pcap>); None means
+# the phase uses tcpdump or is handled specially.
+
+_VERSION = "2.0.0-rc4"
+
+
+# ---------------------------------------------------------------------------
+# Chain-of-custody header
+# ---------------------------------------------------------------------------
+
+def _tool_version(tool: str) -> str:
+    """Return a one-line version string for *tool*, best-effort."""
+    try:
+        result = subprocess.run(
+            [tool, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        first_line = (result.stdout or result.stderr or "unknown").splitlines()[0]
+        return first_line.strip()
+    except Exception:
+        return "unknown"
+
+
+def build_custody_header(pcap_path: pathlib.Path, tool_versions: dict) -> str:
+    """Return a chain-of-custody block for the top of every output file."""
+    sha256 = _sha256(pcap_path)
+    ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    hostname = _best_effort_hostname()
+    lines = [
+        "=" * 72,
+        "Orion-X Phoenix Edition — PCAP Analyzer",
+        f"Version       : {_VERSION}",
+        f"File          : {pcap_path.name}",
+        f"SHA-256       : {sha256}",
+        f"Analysis time : {ts}",
+        f"Host          : {hostname}",
+    ]
+    for name, ver in tool_versions.items():
+        lines.append(f"Tool ({name:<8}): {ver}")
+    lines.append("=" * 72)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _sha256(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _best_effort_hostname() -> str:
+    try:
+        return socket.gethostname()
+    except Exception:
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery
+# ---------------------------------------------------------------------------
+
+def discover_tools() -> dict:
+    """
+    Return a dict of tool_name -> path (or None).
+    Fails loudly if tshark is missing — it is the core dependency.
+    """
+    tools = {}
+    for name in [_TOOL_TSHARK, _TOOL_TCPDUMP]:
+        path = shutil.which(name)
+        tools[name] = path
+    if tools[_TOOL_TSHARK] is None:
+        print(
+            f"ERROR: tshark not found on PATH. "
+            f"Install wireshark-common (tshark) to use pcap-analyzer.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# Subprocess runner
+# ---------------------------------------------------------------------------
+
+def run_tshark(args: list, pcap_path: pathlib.Path, timeout: int = 120) -> str:
+    """Run tshark with *args* against *pcap_path*. Return stdout (may be empty)."""
+    cmd = [_TOOL_TSHARK, "-r", str(pcap_path)] + args
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            stderr_snippet = result.stderr.strip()[:500] if result.stderr else ""
+            return f"[tshark exited {result.returncode}]\n{stderr_snippet}\n"
+        return result.stdout
+    except subprocess.TimeoutExpired:
+        return f"[tshark timed out after {timeout}s for args: {args}]\n"
+    except FileNotFoundError:
+        return "[tshark not found]\n"
+
+
+def run_tcpdump(pcap_path: pathlib.Path, max_packets: int = 200) -> str:
+    """Run tcpdump readable summary. Returns output or an informational note."""
+    if shutil.which(_TOOL_TCPDUMP) is None:
+        return "[tcpdump not on PATH — phase 6 skipped]\n"
+    cmd = [_TOOL_TCPDUMP, "-r", str(pcap_path), "-nn", "-tttt", "-c", str(max_packets)]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        # tcpdump writes summaries to stderr; stdout may be empty
+        output = result.stdout or result.stderr or ""
+        if result.returncode != 0 and not output.strip():
+            return f"[tcpdump exited {result.returncode} with no output]\n"
+        return output
+    except subprocess.TimeoutExpired:
+        return "[tcpdump timed out]\n"
+    except FileNotFoundError:
+        return "[tcpdump not found]\n"
+
+
+# ---------------------------------------------------------------------------
+# Output directory
+# ---------------------------------------------------------------------------
+
+def resolve_output_dir(pcap_path: pathlib.Path, output_dir_arg: str | None) -> pathlib.Path:
+    if output_dir_arg:
+        out = pathlib.Path(output_dir_arg).expanduser()
+    else:
+        ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        stem = pcap_path.stem
+        out = pathlib.Path.home() / "Analysis" / f"{stem}-{ts}"
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Phase runners
+# ---------------------------------------------------------------------------
+
+def run_phases(
+    pcap_path: pathlib.Path,
+    output_dir: pathlib.Path,
+    custody_header: str,
+    quick: bool,
+) -> list:
+    """
+    Execute all analysis phases. Returns a list of (label, filename, excerpt)
+    tuples for the summary report.
+    """
+    results = []
+
+    def write_phase(filename: str, label: str, content: str) -> tuple:
+        filepath = output_dir / filename
+        filepath.write_text(custody_header + content, encoding="utf-8")
+        # Excerpt: first 15 non-empty lines for the summary
+        meaningful = [l for l in content.splitlines() if l.strip()][:15]
+        excerpt = "\n".join(meaningful)
+        print(f"  [phase] {label} -> {filename}")
+        return label, filename, excerpt
+
+    # Phase 1: Capture metadata
+    label = "Phase 1: Capture metadata"
+    print(f"\n[pcap-analyzer] {label}")
+    raw = run_tshark(["-q", "-z", "io,stat,0"], pcap_path)
+    results.append(write_phase("01-metadata.txt", label, raw))
+
+    # Phase 2: Protocol hierarchy
+    label = "Phase 2: Protocol hierarchy"
+    print(f"[pcap-analyzer] {label}")
+    raw = run_tshark(["-q", "-z", "io,phs"], pcap_path)
+    results.append(write_phase("02-protocols.txt", label, raw))
+
+    # Phase 3a: IP conversations
+    label = "Phase 3a: IP conversations"
+    print(f"[pcap-analyzer] {label}")
+    raw = run_tshark(["-q", "-z", "conv,ip"], pcap_path)
+    results.append(write_phase("03-conversations-ip.txt", label, raw))
+
+    # Phase 3b: TCP conversations
+    label = "Phase 3b: TCP conversations"
+    print(f"[pcap-analyzer] {label}")
+    raw = run_tshark(["-q", "-z", "conv,tcp"], pcap_path)
+    results.append(write_phase("03-conversations-tcp.txt", label, raw))
+
+    # Phase 4: IP endpoints
+    label = "Phase 4: IP endpoints"
+    print(f"[pcap-analyzer] {label}")
+    raw = run_tshark(["-q", "-z", "endpoints,ip"], pcap_path)
+    results.append(write_phase("04-endpoints-ip.txt", label, raw))
+
+    if not quick:
+        # Phase 5a: HTTP overview
+        label = "Phase 5a: HTTP overview"
+        print(f"[pcap-analyzer] {label}")
+        raw = run_tshark(["-q", "-z", "http,tree"], pcap_path)
+        results.append(write_phase("05-http.txt", label, raw))
+
+        # Phase 5b: DNS overview
+        label = "Phase 5b: DNS overview"
+        print(f"[pcap-analyzer] {label}")
+        raw = run_tshark(["-q", "-z", "dns,tree"], pcap_path)
+        results.append(write_phase("05-dns.txt", label, raw))
+
+        # Phase 5c: TLS/SSL handshake overview
+        label = "Phase 5c: TLS/SSL overview"
+        print(f"[pcap-analyzer] {label}")
+        raw = run_tshark(["-q", "-z", "ssl,stat,0"], pcap_path)
+        results.append(write_phase("05-tls.txt", label, raw))
+    else:
+        print("[pcap-analyzer] Phase 5 (HTTP/DNS/TLS) skipped — --quick mode")
+
+    # Phase 6: tcpdump readable head (optional)
+    label = "Phase 6: tcpdump readable head"
+    print(f"[pcap-analyzer] {label}")
+    raw = run_tcpdump(pcap_path)
+    results.append(write_phase("06-tcpdump-head.txt", label, raw))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Summary report
+# ---------------------------------------------------------------------------
+
+def write_summary(
+    pcap_path: pathlib.Path,
+    output_dir: pathlib.Path,
+    custody_header: str,
+    phase_results: list,
+    report_path: str | None,
+) -> None:
+    """Write a human-readable summary of all phases."""
+    lines = [custody_header]
+    lines.append(f"PCAP Analysis Summary — {pcap_path.name}")
+    lines.append(f"Output directory: {output_dir}")
+    lines.append("")
+    lines.append("Files produced:")
+    for label, filename, _ in phase_results:
+        lines.append(f"  {filename:<30} {label}")
+    lines.append("")
+    lines.append("Phase excerpts:")
+    lines.append("-" * 72)
+    for label, filename, excerpt in phase_results:
+        lines.append(f"\n--- {label} ({filename}) ---")
+        if excerpt:
+            lines.append(textwrap.indent(excerpt, "  "))
+        else:
+            lines.append("  (no output)")
+    lines.append("")
+    lines.append("=" * 72)
+    lines.append("Analysis complete.")
+    text = "\n".join(lines)
+
+    summary_file = output_dir / "summary.txt"
+    summary_file.write_text(text, encoding="utf-8")
+    print(f"\n[pcap-analyzer] Summary written to: {summary_file}")
+
+    if report_path:
+        rp = pathlib.Path(report_path).expanduser()
+        rp.parent.mkdir(parents=True, exist_ok=True)
+        rp.write_text(text, encoding="utf-8")
+        print(f"[pcap-analyzer] Report also written to: {rp}")
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+def validate_input(pcap_file: str) -> pathlib.Path:
+    """
+    Validate that *pcap_file* exists, is readable, and is a regular file.
+    Fails loudly (exit 1) if validation fails.
+    """
+    path = pathlib.Path(pcap_file).expanduser()
+    if not path.exists():
+        print(f"ERROR: PCAP file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    if not path.is_file():
+        print(f"ERROR: Not a regular file: {path}", file=sys.stderr)
+        sys.exit(1)
+    if not os.access(path, os.R_OK):
+        print(f"ERROR: PCAP file is not readable: {path}", file=sys.stderr)
+        sys.exit(1)
+    if path.stat().st_size == 0:
+        print(f"ERROR: PCAP file is empty (0 bytes): {path}", file=sys.stderr)
+        sys.exit(1)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pcap-analyzer.py",
+        description=textwrap.dedent("""\
+            Orion-X PCAP Analyzer — Structured Traffic Analysis (Bejtlich STA method)
+
+            Analyzes a packet capture through six structured phases using tshark
+            (required) and tcpdump (optional). Each phase writes a dedicated output
+            file with a chain-of-custody header. A summary report collects excerpts
+            from all phases.
+
+            Analysis phases:
+              Phase 1  Capture metadata  (tshark io,stat,0)
+              Phase 2  Protocol hierarchy (tshark io,phs)
+              Phase 3  Conversations     (tshark conv,ip + conv,tcp)
+              Phase 4  Endpoints         (tshark endpoints,ip)
+              Phase 5  App-layer overview (tshark http,tree / dns,tree / ssl,stat,0)
+                       [skipped with --quick]
+              Phase 6  Readable head     (tcpdump -nn -tttt -c 200)
+                       [skipped if tcpdump absent]
+        """),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "pcap_file",
+        help="Path to the PCAP/PCAPNG file to analyze",
+    )
+    parser.add_argument(
+        "--output-dir",
+        metavar="DIR",
+        default=None,
+        help=(
+            "Directory to write phase output files and summary. "
+            "Default: ~/Analysis/<pcap-stem>-<timestamp>/"
+        ),
+    )
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        default=False,
+        help="Skip Phase 5 (HTTP/DNS/TLS) for a faster analysis run",
+    )
+    parser.add_argument(
+        "--report",
+        metavar="PATH",
+        default=None,
+        help="Additionally write the summary report to this path",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    # --- Input validation first (exit 1 on bad file, before tool check) ---
+    # Ordering matters: validate_input exits 1; discover_tools exits 2.
+    # Tests that assert exit-1 on a missing file must not require tshark on PATH.
+    pcap_path = validate_input(args.pcap_file)
+
+    # --- Tool discovery (fails loud with exit 2 if tshark missing) ---
+    tools = discover_tools()
+
+    # --- Resolve output directory ---
+    output_dir = resolve_output_dir(pcap_path, args.output_dir)
+    print(f"[pcap-analyzer] Analyzing: {pcap_path}")
+    print(f"[pcap-analyzer] Output dir: {output_dir}")
+
+    # --- Build tool version map for chain-of-custody ---
+    tool_versions = {}
+    for name in [_TOOL_TSHARK, _TOOL_TCPDUMP]:
+        if tools[name] is not None:
+            tool_versions[name] = _tool_version(name)
+
+    # --- Chain-of-custody header (written to every output file) ---
+    custody_header = build_custody_header(pcap_path, tool_versions)
+
+    # --- Run phases ---
+    phase_results = run_phases(pcap_path, output_dir, custody_header, args.quick)
+
+    # --- Summary ---
+    write_summary(pcap_path, output_dir, custody_header, phase_results, args.report)
+
+    print("[pcap-analyzer] Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pcap-analyzer.py
+++ b/scripts/pcap-analyzer.py
@@ -155,8 +155,8 @@ def discover_tools() -> dict:
         tools[name] = path
     if tools[_TOOL_TSHARK] is None:
         print(
-            f"ERROR: tshark not found on PATH. "
-            f"Install wireshark-common (tshark) to use pcap-analyzer.",
+            "ERROR: tshark not found on PATH. "
+            "Install wireshark-common (tshark) to use pcap-analyzer.",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -245,7 +245,7 @@ def run_phases(
         filepath = output_dir / filename
         filepath.write_text(custody_header + content, encoding="utf-8")
         # Excerpt: first 15 non-empty lines for the summary
-        meaningful = [l for l in content.splitlines() if l.strip()][:15]
+        meaningful = [ln for ln in content.splitlines() if ln.strip()][:15]
         excerpt = "\n".join(meaningful)
         print(f"  [phase] {label} -> {filename}")
         return label, filename, excerpt

--- a/scripts/pcap-analyzer.py
+++ b/scripts/pcap-analyzer.py
@@ -56,6 +56,10 @@ Exit codes:
     is reference-only and is NOT staged into the ISO.
 """
 
+# PEP 563: defer annotation evaluation so PEP 604 union syntax (X | None) works
+# on Debian Bullseye Python 3.9 without `Optional[X]`. @decision DEC-PHASE9-019.
+from __future__ import annotations
+
 import argparse
 import datetime
 import hashlib

--- a/tests/integration/test-iso-content-presence.sh
+++ b/tests/integration/test-iso-content-presence.sh
@@ -403,7 +403,58 @@ else
 fi
 
 # ===========================================================================
-# 12. File count sanity check (renumbered from 8)
+# 12. W9-2a: pcap-analyzer.py staged + symlinked; fail2ban installed
+#
+# @decision DEC-PHASE9-017: pcap-analyzer.py is the modernized STA PCAP tool
+#   staged via the existing scripts/ rsync path (stage_application_content).
+# @decision DEC-PHASE9-018: fail2ban replaces gecko/bin/start-denyhosts.sh;
+#   enabled by its own package postinst (no custom unit needed).
+# ===========================================================================
+section "W9-2a: pcap-analyzer.py staged, symlinked; fail2ban installed"
+
+# (a) /opt/orionx/scripts/pcap-analyzer.py staged in chroot
+if [[ -f "$SQF/opt/orionx/scripts/pcap-analyzer.py" ]]; then
+    pass "/opt/orionx/scripts/pcap-analyzer.py staged in chroot (DEC-PHASE9-017)"
+else
+    fail "/opt/orionx/scripts/pcap-analyzer.py staged in chroot" \
+         "stage_application_content rsyncs scripts/ — ensure pcap-analyzer.py exists in repo scripts/"
+fi
+
+# Check executable bit on the staged copy
+if [[ -f "$SQF/opt/orionx/scripts/pcap-analyzer.py" ]] && \
+   [[ -x "$SQF/opt/orionx/scripts/pcap-analyzer.py" ]]; then
+    pass "/opt/orionx/scripts/pcap-analyzer.py is executable in chroot"
+else
+    fail "/opt/orionx/scripts/pcap-analyzer.py is executable in chroot" \
+         "0700 hook sets chmod 755 on all scripts/ files — check hook execution"
+fi
+
+# (b) /usr/bin/pcap-analyzer.py symlink present (created by 0700 hook)
+if [[ -L "$SQF/usr/bin/pcap-analyzer.py" ]]; then
+    pass "/usr/bin/pcap-analyzer.py symlink present in chroot (0700 hook)"
+elif [[ -f "$SQF/usr/bin/pcap-analyzer.py" ]]; then
+    pass "/usr/bin/pcap-analyzer.py present in chroot (as regular file)"
+else
+    fail "/usr/bin/pcap-analyzer.py symlink present in chroot" \
+         "0700-orionx-setup.hook.chroot SCRIPT_MAP must include pcap-analyzer.py"
+fi
+
+# (c) fail2ban installed in chroot (dpkg status or binary fallback)
+# || true: grep returns 1 on no-match; under pipefail that kills the script
+# before the if-branch is reached. Same guard pattern as section 8. DEC-PHASE9-014.
+if [[ -f "$DPKG_STATUS" ]] && grep -q "^Package: fail2ban$" "$DPKG_STATUS" 2>/dev/null; then
+    pass "package installed in chroot: fail2ban (dpkg status)"
+elif [[ -f "$SQF/usr/bin/fail2ban-client" ]]; then
+    pass "package installed in chroot: fail2ban (binary present: fail2ban-client)"
+elif [[ -f "$SQF/usr/sbin/fail2ban-server" ]]; then
+    pass "package installed in chroot: fail2ban (binary present: fail2ban-server)"
+else
+    fail "package installed in chroot: fail2ban" \
+         "fail2ban not found in dpkg/status or as binary — check orionx.list.chroot includes fail2ban"
+fi
+
+# ===========================================================================
+# 13. File count sanity check (renumbered from 12)
 # ===========================================================================
 section "File count sanity"
 

--- a/tests/unit/test_build_iso.sh
+++ b/tests/unit/test_build_iso.sh
@@ -463,6 +463,64 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
+# T21: fail2ban present as uncommented entry in orionx.list.chroot (W9-2a)
+#
+# @decision DEC-PHASE9-018: fail2ban replaces gecko/bin/start-denyhosts.sh.
+# The package must appear as a bare uncommented line so live-build installs it.
+# ---------------------------------------------------------------------------
+echo "[T21] fail2ban in orionx.list.chroot (W9-2a DEC-PHASE9-018)"
+PKG_LIST_F2B="$REPO_ROOT/iso/config/package-lists/orionx.list.chroot"
+if [[ -f "$PKG_LIST_F2B" ]]; then
+    if grep -qE '^fail2ban$' "$PKG_LIST_F2B"; then
+        pass "fail2ban present as uncommented entry in orionx.list.chroot"
+    else
+        fail "fail2ban present as uncommented entry in orionx.list.chroot" \
+             "Expected a bare 'fail2ban' line (no leading #) in $PKG_LIST_F2B"
+    fi
+    # Confirm DEC-PHASE9-018 annotation accompanies the entry
+    if grep -q "DEC-PHASE9-018" "$PKG_LIST_F2B"; then
+        pass "DEC-PHASE9-018 annotation present alongside fail2ban entry"
+    else
+        fail "DEC-PHASE9-018 annotation present alongside fail2ban entry" \
+             "W9-2a requires @decision DEC-PHASE9-018 comment near the fail2ban line"
+    fi
+else
+    fail "fail2ban check: orionx.list.chroot not found at $PKG_LIST_F2B"
+    fail "DEC-PHASE9-018 annotation check: orionx.list.chroot missing"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# T22: pcap-analyzer.py present in scripts/ (W9-2a)
+#
+# The build pipeline (stage_application_content in build-iso.sh) rsyncs
+# scripts/ into includes.chroot — pcap-analyzer.py must exist at the source
+# path so it gets staged into the ISO automatically.
+# ---------------------------------------------------------------------------
+echo "[T22] scripts/pcap-analyzer.py exists and is executable (W9-2a)"
+PCAP_SCRIPT="$REPO_ROOT/scripts/pcap-analyzer.py"
+run_test "scripts/pcap-analyzer.py exists" "[[ -f '$PCAP_SCRIPT' ]]"
+run_test "scripts/pcap-analyzer.py is executable" "[[ -x '$PCAP_SCRIPT' ]]"
+# Shebang check
+if [[ -f "$PCAP_SCRIPT" ]]; then
+    PCAP_SHEBANG="$(head -n1 "$PCAP_SCRIPT")"
+    if [[ "$PCAP_SHEBANG" == "#!/usr/bin/env python3" ]]; then
+        pass "scripts/pcap-analyzer.py shebang is #!/usr/bin/env python3"
+    else
+        fail "scripts/pcap-analyzer.py shebang is #!/usr/bin/env python3" \
+             "Got: $PCAP_SHEBANG"
+    fi
+    PCAP_CONTENT="$(cat "$PCAP_SCRIPT")"
+    if [[ "$PCAP_CONTENT" == *"DEC-PHASE9-017"* ]]; then
+        pass "scripts/pcap-analyzer.py has @decision DEC-PHASE9-017"
+    else
+        fail "scripts/pcap-analyzer.py has @decision DEC-PHASE9-017" \
+             "W9-2a requires @decision DEC-PHASE9-017 annotation in the module"
+    fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo "================================================================"

--- a/tests/unit/test_orionx_setup_hook_unit.sh
+++ b/tests/unit/test_orionx_setup_hook_unit.sh
@@ -138,10 +138,18 @@ else
     fail "has @status accepted"
 fi
 
+# W9-2a: DEC-PHASE9-017 annotation must be present (pcap-analyzer.py entry)
+if [[ "$HOOK_CONTENT" == *"DEC-PHASE9-017"* ]]; then
+    pass "has DEC-PHASE9-017 annotation (W9-2a pcap-analyzer.py entry)"
+else
+    fail "has DEC-PHASE9-017 annotation (W9-2a pcap-analyzer.py entry)" \
+         "W9-2a requires DEC-PHASE9-017 comment in the SCRIPT_MAP block"
+fi
+
 # ===========================================================================
-# 4. PATH symlinks for all 8 Orion-X scripts
+# 4. PATH symlinks for all 9 Orion-X scripts (W9-2a: +pcap-analyzer.py)
 # ===========================================================================
-section "PATH symlinks for all 8 scripts"
+section "PATH symlinks for all 9 scripts (W9-2a: pcap-analyzer.py added)"
 
 EXPECTED_SCRIPTS=(
     "orionx-mesh"
@@ -152,6 +160,7 @@ EXPECTED_SCRIPTS=(
     "toggle-theme.sh"
     "run-lynis.sh"
     "download-samples.sh"
+    "pcap-analyzer.py"
 )
 
 for script in "${EXPECTED_SCRIPTS[@]}"; do
@@ -169,6 +178,14 @@ if [[ "$HOOK_CONTENT" == *"mesh/orionx-mesh"* ]]; then
 else
     fail "orionx-mesh uses mesh/ subpath (not flat scripts/ root)" \
          "Expected /opt/orionx/scripts/mesh/orionx-mesh path"
+fi
+
+# W9-2a: pcap-analyzer.py maps to the correct target path
+if [[ "$HOOK_CONTENT" == *'["pcap-analyzer.py"]="/opt/orionx/scripts/pcap-analyzer.py"'* ]]; then
+    pass "pcap-analyzer.py maps to /opt/orionx/scripts/pcap-analyzer.py (DEC-PHASE9-017)"
+else
+    fail "pcap-analyzer.py maps to /opt/orionx/scripts/pcap-analyzer.py" \
+         "SCRIPT_MAP entry missing or wrong target for pcap-analyzer.py"
 fi
 
 # Verify /usr/bin/ is the symlink target directory

--- a/tests/unit/test_pcap_analyzer.sh
+++ b/tests/unit/test_pcap_analyzer.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Unit tests for scripts/pcap-analyzer.py (W9-2a gecko-legacy port)
+#
+# Validates the Python tool without requiring a live ISO or root access.
+# Asserts: file existence, executable bit, Python compile-clean, --help,
+# error path on nonexistent input, DEC-PHASE9-017 annotation, Bejtlich STA
+# phases present in docstring.
+#
+# @decision DEC-PHASE9-017
+# @title W9-2a: pcap-analyzer.py — modernized STA PCAP tool unit tests
+# @status accepted
+# @rationale The tool runs inside the live ISO (or as a standalone CLI on any
+#   host with tshark). These tests exercise: (a) structural assertions that can
+#   run on any macOS/Linux host without tshark installed; (b) the --help exit-0
+#   path (argparse-only, no PCAP needed); (c) the fail-loud path for a
+#   nonexistent input file (exit 1 before tshark is invoked). The compound-
+#   interaction test verifies that the full CLI call chain — arg parsing ->
+#   input validation -> loud error + non-zero exit — works correctly. These
+#   assertions substitute for direct PCAP analysis (which requires tshark and a
+#   real capture file) in the local dev/CI-macOS environment.
+#
+# Usage: bash tests/unit/test_pcap_analyzer.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOL="$REPO_ROOT/scripts/pcap-analyzer.py"
+
+# ---------------------------------------------------------------------------
+# Test counters
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+SKIP=0
+
+if [[ -t 1 ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[0;33m'
+    NC=$'\033[0m'
+else
+    RED=""
+    GREEN=""
+    YELLOW=""
+    NC=""
+fi
+
+pass() {
+    ((PASS+=1))
+    echo "${GREEN}  PASS${NC}: $1"
+}
+
+fail() {
+    ((FAIL+=1))
+    echo "${RED}  FAIL${NC}: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "        $2"
+    fi
+}
+
+skip() {
+    ((SKIP+=1))
+    echo "${YELLOW}  SKIP${NC}: $1 — $2"
+}
+
+section() {
+    echo ""
+    echo "--- $1 ---"
+}
+
+echo "=== W9-2a: pcap-analyzer.py — Unit Tests ==="
+
+TOOL_CONTENT="$(cat "$TOOL")"
+
+# ===========================================================================
+# 1. File existence and basic properties
+# ===========================================================================
+section "File existence and basic properties"
+
+if [[ -f "$TOOL" ]]; then
+    pass "pcap-analyzer.py exists at scripts/pcap-analyzer.py"
+else
+    fail "pcap-analyzer.py exists at scripts/pcap-analyzer.py" \
+         "Not found: $TOOL"
+    echo ""
+    echo "FATAL: tool file not found — cannot continue."
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+if [[ -x "$TOOL" ]]; then
+    pass "pcap-analyzer.py is executable"
+else
+    fail "pcap-analyzer.py is executable" \
+         "Run: chmod +x $TOOL  or  git update-index --chmod=+x scripts/pcap-analyzer.py"
+fi
+
+FIRST_LINE="$(head -n1 "$TOOL")"
+if [[ "$FIRST_LINE" == "#!/usr/bin/env python3" ]]; then
+    pass "shebang is #!/usr/bin/env python3"
+else
+    fail "shebang is #!/usr/bin/env python3" "Got: $FIRST_LINE"
+fi
+
+# ===========================================================================
+# 2. Python syntax clean (py_compile)
+# ===========================================================================
+section "Python syntax clean"
+
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -m py_compile "$TOOL" 2>&1; then
+        pass "python3 -m py_compile passes clean"
+    else
+        fail "python3 -m py_compile passes clean" \
+             "Syntax error in pcap-analyzer.py"
+    fi
+else
+    skip "python3 -m py_compile" "python3 not on PATH"
+fi
+
+# ast.parse round-trip (strict parse, not just compile)
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -c "import ast; ast.parse(open('$TOOL').read())" 2>&1; then
+        pass "ast.parse round-trip clean"
+    else
+        fail "ast.parse round-trip clean" \
+             "ast.parse failed on pcap-analyzer.py"
+    fi
+else
+    skip "ast.parse" "python3 not on PATH"
+fi
+
+# ===========================================================================
+# 3. Decision annotation DEC-PHASE9-017
+# ===========================================================================
+section "@decision DEC-PHASE9-017 annotation"
+
+if [[ "$TOOL_CONTENT" == *"@decision DEC-PHASE9-017"* ]]; then
+    pass "has @decision DEC-PHASE9-017"
+else
+    fail "has @decision DEC-PHASE9-017" \
+         "@decision annotation missing or wrong ID"
+fi
+
+if [[ "$TOOL_CONTENT" == *"@status accepted"* ]]; then
+    pass "has @status accepted"
+else
+    fail "has @status accepted"
+fi
+
+if [[ "$TOOL_CONTENT" == *"gecko"* ]]; then
+    pass "docstring references gecko legacy origin"
+else
+    fail "docstring references gecko legacy origin" \
+         "Module docstring should document the W9-2a gecko port rationale"
+fi
+
+# ===========================================================================
+# 4. Bejtlich STA phases documented in module docstring
+# ===========================================================================
+section "Bejtlich STA phases in module docstring"
+
+for phase_keyword in \
+    "Phase 1" \
+    "Phase 2" \
+    "Phase 3" \
+    "Phase 4" \
+    "Phase 5" \
+    "Phase 6"; do
+    if [[ "$TOOL_CONTENT" == *"$phase_keyword"* ]]; then
+        pass "module documents: $phase_keyword"
+    else
+        fail "module documents: $phase_keyword" \
+             "Phase missing from module docstring or comments"
+    fi
+done
+
+# Specific methodology keywords
+for keyword in "tshark" "tcpdump" "argparse" "subprocess" "Bejtlich"; do
+    if [[ "$TOOL_CONTENT" == *"$keyword"* ]]; then
+        pass "tool references: $keyword"
+    else
+        fail "tool references: $keyword" \
+             "Expected reference to $keyword in pcap-analyzer.py"
+    fi
+done
+
+# ===========================================================================
+# 5. stdlib-only (no non-stdlib imports)
+# ===========================================================================
+section "stdlib-only imports (no extra pip deps)"
+
+STDLIB_MODULES="argparse datetime hashlib os pathlib shutil socket subprocess sys textwrap"
+# Extract import lines and check none are non-stdlib
+IMPORT_LINES="$(grep -E '^import |^from ' "$TOOL" 2>/dev/null || true)"
+UNEXPECTED_IMPORTS=""
+while IFS= read -r line; do
+    # Extract module name (first token after import / from)
+    mod="$(echo "$line" | awk '{print $2}' | cut -d. -f1)"
+    is_std=false
+    for std in $STDLIB_MODULES; do
+        if [[ "$mod" == "$std" ]]; then
+            is_std=true
+            break
+        fi
+    done
+    if ! $is_std; then
+        UNEXPECTED_IMPORTS="$UNEXPECTED_IMPORTS $mod"
+    fi
+done <<< "$IMPORT_LINES"
+
+if [[ -z "${UNEXPECTED_IMPORTS// /}" ]]; then
+    pass "no non-stdlib imports (stdlib-only tool, no pip deps)"
+else
+    fail "no non-stdlib imports" \
+         "Found unexpected imports:$UNEXPECTED_IMPORTS"
+fi
+
+# ===========================================================================
+# 6. CLI: --help exits 0 and shows usage
+# ===========================================================================
+section "--help exits 0 and shows usage"
+
+if command -v python3 >/dev/null 2>&1; then
+    HELP_OUTPUT="$(python3 "$TOOL" --help 2>&1 || true)"
+    HELP_EXIT="$(python3 "$TOOL" --help >/dev/null 2>&1; echo $?)"
+
+    if [[ "$HELP_EXIT" -eq 0 ]]; then
+        pass "--help exits 0"
+    else
+        fail "--help exits 0" "Got exit code: $HELP_EXIT"
+    fi
+
+    if [[ "$HELP_OUTPUT" == *"pcap_file"* || "$HELP_OUTPUT" == *"pcap-analyzer"* ]]; then
+        pass "--help output includes pcap_file positional or tool name"
+    else
+        fail "--help output includes pcap_file positional or tool name" \
+             "Got: $HELP_OUTPUT"
+    fi
+
+    if [[ "$HELP_OUTPUT" == *"Phase"* || "$HELP_OUTPUT" == *"phase"* ]]; then
+        pass "--help output mentions analysis phases"
+    else
+        fail "--help output mentions analysis phases" \
+             "Got: $HELP_OUTPUT"
+    fi
+
+    if [[ "$HELP_OUTPUT" == *"--quick"* ]]; then
+        pass "--help shows --quick flag"
+    else
+        fail "--help shows --quick flag" \
+             "Got: $HELP_OUTPUT"
+    fi
+
+    if [[ "$HELP_OUTPUT" == *"--report"* ]]; then
+        pass "--help shows --report flag"
+    else
+        fail "--help shows --report flag" \
+             "Got: $HELP_OUTPUT"
+    fi
+
+    if [[ "$HELP_OUTPUT" == *"--output-dir"* ]]; then
+        pass "--help shows --output-dir flag"
+    else
+        fail "--help shows --output-dir flag" \
+             "Got: $HELP_OUTPUT"
+    fi
+else
+    skip "--help test" "python3 not on PATH"
+fi
+
+# ===========================================================================
+# 7. CLI: nonexistent PCAP file fails loud with non-zero exit
+#    (input validation before tshark is invoked — no tshark needed)
+# ===========================================================================
+section "Fail-loud: nonexistent PCAP input exits non-zero"
+
+if command -v python3 >/dev/null 2>&1; then
+    NONEXIST_EXIT=0
+    NONEXIST_OUTPUT=""
+    NONEXIST_OUTPUT="$(python3 "$TOOL" /nonexistent/path/capture.pcap 2>&1)" || NONEXIST_EXIT=$?
+
+    if [[ "$NONEXIST_EXIT" -ne 0 ]]; then
+        pass "nonexistent PCAP exits non-zero (exit $NONEXIST_EXIT)"
+    else
+        fail "nonexistent PCAP exits non-zero" \
+             "Got exit 0 — input validation is not failing loud"
+    fi
+
+    if [[ "$NONEXIST_OUTPUT" == *"not found"* || "$NONEXIST_OUTPUT" == *"ERROR"* || "$NONEXIST_OUTPUT" == *"No such"* ]]; then
+        pass "nonexistent PCAP produces clear error message"
+    else
+        fail "nonexistent PCAP produces clear error message" \
+             "Got: $NONEXIST_OUTPUT"
+    fi
+else
+    skip "fail-loud input test" "python3 not on PATH"
+fi
+
+# ===========================================================================
+# 8. Compound-interaction: full CLI arg-parse -> validate -> error chain
+#    This exercises the real production sequence: argument parsing hand-off to
+#    validate_input(), which must exit 1 (not 2, not 0) on a missing file.
+#    Exit code 2 is reserved for the missing-tshark case; 1 is file-not-found.
+# ===========================================================================
+section "Compound-interaction: arg-parse -> validate -> exit-1 chain"
+
+if command -v python3 >/dev/null 2>&1; then
+    CI_EXIT=0
+    python3 "$TOOL" /absolutely/nonexistent/file.pcap 2>/dev/null || CI_EXIT=$?
+
+    # Input validation fires before tool discovery: exit must be 1 (not 2)
+    if [[ "$CI_EXIT" -eq 1 ]]; then
+        pass "compound-interaction: file-not-found exits 1 (not 2 = missing-tool)"
+    else
+        fail "compound-interaction: file-not-found exits 1" \
+             "Got exit code $CI_EXIT — check validate_input() exit code vs tool-discovery exit code"
+    fi
+else
+    skip "compound-interaction test" "python3 not on PATH"
+fi
+
+# ===========================================================================
+# 9. ShellCheck (not applicable for Python, but check the file for bash idioms)
+#    Static check: no bash is embedded in the Python file
+# ===========================================================================
+section "No embedded bash in Python file"
+
+if grep -q '#!/bin/bash' "$TOOL"; then
+    fail "Python file does not embed a bash shebang" \
+         "Found #!/bin/bash inside pcap-analyzer.py — tool must be pure Python"
+else
+    pass "Python file is pure Python (no embedded bash shebang)"
+fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo ""
+echo "==========================================="
+TOTAL=$(( PASS + FAIL + SKIP ))
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped (total: $TOTAL)"
+echo "==========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/unit/test_pcap_analyzer.sh
+++ b/tests/unit/test_pcap_analyzer.sh
@@ -392,6 +392,35 @@ else
 fi
 
 # ===========================================================================
+# 11. ruff lint check (F541 / E741 regression guard)
+#
+# @decision DEC-PHASE9-020
+# @title iter-3: ruff F541/E741 check added to unit suite
+# @status accepted
+# @rationale iter-3 added ruff F541 check to catch f-string-without-placeholder
+#   defects before the CI lint stage. E741 (ambiguous variable name) is also
+#   detected by ruff and was the third error in the same batch. If ruff is not
+#   installed locally (macOS dev box), the assertion is skipped gracefully so
+#   the test suite does not fail on machines that lack ruff. CI always has ruff
+#   via make lint-python, so the gate is enforced there unconditionally.
+# ===========================================================================
+section "ruff lint check (F541/E741 regression guard)"
+
+if command -v ruff >/dev/null 2>&1; then
+    RUFF_OUTPUT=""
+    RUFF_EXIT=0
+    RUFF_OUTPUT="$( ruff check "$TOOL" 2>&1 )" || RUFF_EXIT=$?
+    if [[ "$RUFF_EXIT" -eq 0 ]]; then
+        pass "T11: ruff check exits 0 (no F541/E741 or other ruff errors)"
+    else
+        fail "T11: ruff check exits 0" \
+             "ruff found errors: $RUFF_OUTPUT"
+    fi
+else
+    skip "T11: ruff lint check" "ruff not on PATH — install via 'pip install ruff' or 'brew install ruff'"
+fi
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/unit/test_pcap_analyzer.sh
+++ b/tests/unit/test_pcap_analyzer.sh
@@ -193,7 +193,7 @@ done
 # ===========================================================================
 section "stdlib-only imports (no extra pip deps)"
 
-STDLIB_MODULES="argparse datetime hashlib os pathlib shutil socket subprocess sys textwrap"
+STDLIB_MODULES="__future__ argparse datetime hashlib os pathlib shutil socket subprocess sys textwrap"
 # Extract import lines and check none are non-stdlib
 IMPORT_LINES="$(grep -E '^import |^from ' "$TOOL" 2>/dev/null || true)"
 UNEXPECTED_IMPORTS=""
@@ -328,6 +328,61 @@ fi
 #    Static check: no bash is embedded in the Python file
 # ===========================================================================
 section "No embedded bash in Python file"
+
+# ===========================================================================
+# 10. PEP 563 future-annotations guard (F-W9-2a-001 / DEC-PHASE9-019)
+#     Ensures the module is importable on Debian Bullseye Python 3.9 which
+#     evaluates annotations at definition time and rejects PEP 604 X|None
+#     syntax. The `from __future__ import annotations` must appear before any
+#     other import and be accompanied by the @decision DEC-PHASE9-019 comment.
+#
+#     Additionally, a module-import simulation test drives the ACTUAL Python
+#     import path to confirm the file loads clean — the compound interaction
+#     that would have caught F-W9-2a-001 at CI time if it had existed earlier.
+# ===========================================================================
+section "PEP 563 future-annotations guard (F-W9-2a-001, DEC-PHASE9-019)"
+
+# T10-a: `from __future__ import annotations` is present AND appears before
+#         `import argparse` (i.e. it is the first real import after the docstring,
+#         as required by Python — __future__ imports must precede all other imports)
+FUTURE_LINE="$(grep -n "from __future__ import annotations" "$TOOL" | head -1 | cut -d: -f1)"
+ARGPARSE_LINE="$(grep -n "^import argparse" "$TOOL" | head -1 | cut -d: -f1)"
+if [[ -n "$FUTURE_LINE" && -n "$ARGPARSE_LINE" && "$FUTURE_LINE" -lt "$ARGPARSE_LINE" ]]; then
+    pass "T10-a: 'from __future__ import annotations' present and precedes stdlib imports (line $FUTURE_LINE < $ARGPARSE_LINE)"
+else
+    fail "T10-a: 'from __future__ import annotations' present and precedes stdlib imports" \
+         "PEP 563 guard missing or mis-ordered — module will crash on Python 3.9 (Bullseye). future_line=${FUTURE_LINE:-MISSING} argparse_line=${ARGPARSE_LINE:-MISSING}"
+fi
+
+# T10-b: @decision DEC-PHASE9-019 annotation present in the file (near the future import)
+if grep -q "DEC-PHASE9-019" "$TOOL"; then
+    pass "T10-b: @decision DEC-PHASE9-019 annotation present in pcap-analyzer.py"
+else
+    fail "T10-b: @decision DEC-PHASE9-019 annotation present in pcap-analyzer.py" \
+         "Missing decision annotation — add '@decision DEC-PHASE9-019' comment above the future import"
+fi
+
+# T10-c: module import simulation — proves the file actually loads clean
+#        (catches PEP 604 / annotation eval errors that py_compile misses)
+if command -v python3 >/dev/null 2>&1; then
+    IMPORT_EXIT=0
+    IMPORT_OUTPUT=""
+    IMPORT_OUTPUT="$(python3 -W error::DeprecationWarning -c "
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location('pcap_analyzer', '$TOOL')
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+" 2>&1)" || IMPORT_EXIT=$?
+
+    if [[ "$IMPORT_EXIT" -eq 0 ]]; then
+        pass "T10-c: module import simulation exits 0 (clean load on this Python)"
+    else
+        fail "T10-c: module import simulation exits 0" \
+             "Import failed (exit $IMPORT_EXIT): $IMPORT_OUTPUT"
+    fi
+else
+    skip "T10-c: module import simulation" "python3 not on PATH"
+fi
 
 if grep -q '#!/bin/bash' "$TOOL"; then
     fail "Python file does not embed a bash shebang" \


### PR DESCRIPTION
Closes #50.

## What this slice ports

Two high-value items from /Users/jarocki/cyber/gecko/bin/ into the Orion-X
Phoenix cyberdeck, parallel-to-rc4 capable, recorded in MASTER_PLAN.md as W9-2a:

- **scripts/pcap-analyzer.py** (NEW, 470 LOC) — modernized Python 3 wrapper
  around already-installed PCAP tools (tshark, tcpdump), implementing the
  Bejtlich STA (Structured Traffic Analysis) 6-phase methodology that the
  legacy gecko/bin/analyze-pcap.sh used. Standard-library only. Chain-of-
  custody header (SHA256, hostname, tool versions) on every output file.
  argparse interface (--output-dir, --quick, --report). Fail-loud on
  missing tshark. DEC-PHASE9-017.

- **fail2ban** added to iso/config/package-lists/orionx.list.chroot —
  replaces the dead denyhosts concept from gecko/bin/start-denyhosts.sh.
  SSH brute-force defense; daemon enabled by Debian postinst (same pattern
  as NetworkManager in W9-1, no custom systemd unit). DEC-PHASE9-018.

threat-posture-manager.py is DEFERRED to W9-3 (depends on W9-2 Control
Center surface).

## Cascade (cascade-consolidation discipline)

- iter-1 (2c2d6e9 -> b23bb81): full slice with pcap-analyzer.py + fail2ban
  + 0700 hook 9th symlink entry + 4 test extensions.
- iter-2 (f3163b3): reviewer caught F-W9-2a-001 blocking — PEP 604 union
  syntax `str | None` (3.10+) breaks Python 3.9.2 import on Bullseye live
  ISO. Fixed via PEP 563 `from __future__ import annotations` (single-line
  fix, future-proof; no annotation rewrites). DEC-PHASE9-019. New T10 test
  group asserts the import + does importlib.util module-load simulation
  to catch this class going forward.

## Local evidence (macOS host)

- 864 unit tests pass, 0 failures across 30 test files.
- python3 -m py_compile + ast.parse + importlib module-load simulation all clean.
- pcap-analyzer.py --help exits 0; fail-loud exit=1 on missing input.
- shellcheck + bash -n clean on all edited files.
- 7 pre-existing SC1102/SC2016/SC2034 in tests/unit/test_build_iso.sh
  T1-T20 (unchanged by this slice; reviewer flagged as note).

## Definitive CI proof gates (this PR's QEMU Boot Test must reach green)

- Build ISO in debian:bullseye container — confirm fail2ban package installs.
- Verify Orion-X content present in ISO — section 12 asserts
  /opt/orionx/scripts/pcap-analyzer.py staged + executable;
  /usr/bin/pcap-analyzer.py symlink present; fail2ban installed in chroot dpkg.
- Run QEMU boot test — confirms image still boots after additions.

## Scope

7 files: scripts/pcap-analyzer.py (new), iso/config/package-lists/orionx.list.chroot,
iso/config/hooks/live/0700-orionx-setup.hook.chroot, tests/unit/test_pcap_analyzer.sh
(new), tests/unit/test_orionx_setup_hook_unit.sh, tests/unit/test_build_iso.sh,
tests/integration/test-iso-content-presence.sh. No hooks/normal, no
includes.chroot, no MASTER_PLAN.md, no release.yml.
