### PR TITLE
feat(phase9): W9-2 — GTK Orion-X Control Center + XFCE panel widgets (rc5 candidate, closes #45)

### DIFF
--- a/iso/config/hooks/live/0700-orionx-setup.hook.chroot
+++ b/iso/config/hooks/live/0700-orionx-setup.hook.chroot
@@ -66,6 +66,11 @@ declare -A SCRIPT_MAP=(
     # tshark (already installed) + optional tcpdump. CLI-only; no .desktop
     # launcher here — that is deferred to the W9-2 Control Center slice.
     ["pcap-analyzer.py"]="/opt/orionx/scripts/pcap-analyzer.py"
+    # W9-2: GTK Orion-X Control Center — one-click cyberdeck control surface.
+    # Launches directly as a GTK window (no xfce4-terminal wrapper needed).
+    # Phase 10 slices (W10-1 through W10-6) plug into its placeholder sections.
+    # @decision DEC-PHASE10-005: Control Center ships ahead of Nebula AI runtime.
+    ["orionx-control-center"]="/opt/orionx/scripts/control_center/orionx-control-center"
 )
 
 for name in "${!SCRIPT_MAP[@]}"; do
@@ -142,6 +147,20 @@ Comment=Start Orion-X WireGuard mesh (one-click)
 Exec=xfce4-terminal --hold -e "bash -c 'sudo orionx-mesh join; exec bash'"
 Icon=network-wireless
 Categories=Network;
+DESKTOP_EOF
+
+# GTK Control Center — launches directly as a GTK window, NOT via xfce4-terminal.
+# DEC-PHASE9-006: no lxterminal in any Exec line (lxterminal is NOT installed).
+# DEC-PHASE10-005: Control Center ships ahead of Phase 10 Nebula AI; Nebula
+# and Auto-Healing sections are placeholders that W10-1..W10-6 populate.
+cat > /usr/share/applications/orionx-control-center.desktop << 'DESKTOP_EOF'
+[Desktop Entry]
+Type=Application
+Name=Orion-X Control Center
+Comment=Orion-X cyberdeck control surface (Network, Mesh, Comms, IR, Nebula AI)
+Exec=/usr/bin/orionx-control-center
+Icon=preferences-desktop
+Categories=System;Security;
 DESKTOP_EOF
 
 # ---------------------------------------------------------------------------

--- a/iso/config/includes.chroot/etc/xdg/autostart/nm-applet.desktop
+++ b/iso/config/includes.chroot/etc/xdg/autostart/nm-applet.desktop
@@ -1,0 +1,17 @@
+# nm-applet autostart desktop file.
+#
+# NOTE: network-manager-gnome ships /etc/xdg/autostart/nm-applet.desktop
+# via its own package postinst.  This staged copy is belt-and-suspenders:
+# it ensures the file is present even if the postinst has not run when the
+# live-build hook executes.  In the final squashfs the package-installed
+# version takes precedence (identical content).  Do NOT remove this file —
+# it is the required_paths assertion anchor for the scope manifest.
+#
+# @decision DEC-PHASE9-004: nm-applet autostart via xdg/autostart (W9-1).
+[Desktop Entry]
+Type=Application
+Name=Network Manager Applet
+Comment=Manage your network connections
+Exec=nm-applet
+X-GNOME-Autostart-enabled=true
+NoDisplay=false

--- a/iso/config/includes.chroot/etc/xdg/autostart/orionx-control-center.desktop
+++ b/iso/config/includes.chroot/etc/xdg/autostart/orionx-control-center.desktop
@@ -1,0 +1,15 @@
+# Orion-X Control Center autostart entry.
+#
+# X-GNOME-Autostart-enabled=false — operator-launched per click.
+# Matches DEC-PHASE10-005 sequencing: Control Center ships as a
+# manually-launched GTK app; auto-launch on first boot is an operator
+# opt-in that future slices may enable via xfce session settings.
+# To enable auto-launch: set X-GNOME-Autostart-enabled=true here.
+[Desktop Entry]
+Type=Application
+Name=Orion-X Control Center
+Comment=Orion-X cyberdeck control surface (available as auto-launch on first boot if operator opts in)
+Exec=/usr/bin/orionx-control-center
+Icon=preferences-desktop
+X-GNOME-Autostart-enabled=false
+NoDisplay=true

--- a/iso/config/includes.chroot/usr/share/applications/orionx-control-center.desktop
+++ b/iso/config/includes.chroot/usr/share/applications/orionx-control-center.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Orion-X Control Center
+Comment=Orion-X cyberdeck control surface (Network, Mesh, Comms, IR, Nebula AI)
+Exec=/usr/bin/orionx-control-center
+Icon=preferences-desktop
+Categories=System;Security;

--- a/iso/config/package-lists/orionx.list.chroot
+++ b/iso/config/package-lists/orionx.list.chroot
@@ -187,6 +187,18 @@ python3-dev
 python3-numpy
 python3-scapy
 
+# Phase 9 W9-2: GTK Control Center + XFCE panel widgets (Python + GTK 3 + genmon)
+# @decision DEC-PHASE10-005 — Control Center ships ahead of Phase 10 Nebula AI;
+# Phase 10 slices plug into the placeholder sections (Nebula, Auto-Healing).
+# python3-gi: PyGObject GLib/GTK bindings (Python 3, Debian Bullseye package)
+python3-gi
+# gir1.2-gtk-3.0: GObject introspection data for GTK 3
+gir1.2-gtk-3.0
+# gir1.2-glib-2.0: GObject introspection data for GLib 2
+gir1.2-glib-2.0
+# xfce4-genmon-plugin: generic monitor plugin for XFCE panel (drives panel widgets)
+xfce4-genmon-plugin
+
 # Custom packages (will be installed from config/packages.chroot/)
 # orionx-custom-tools
 # orionx-theme

--- a/scripts/control_center/__init__.py
+++ b/scripts/control_center/__init__.py
@@ -1,0 +1,12 @@
+"""
+Orion-X Control Center — package marker.
+
+This package ships under scripts/control_center/ and is staged into the
+ISO at /opt/orionx/scripts/control_center/ by stage_application_content()
+in scripts/build-iso.sh (no build-script changes required — the existing
+rsync of scripts/ handles it automatically).
+
+Entry point: scripts/control_center/orionx-control-center (executable script,
+no .py extension, #!/usr/bin/env python3 shebang).
+"""
+from __future__ import annotations

--- a/scripts/control_center/app.py
+++ b/scripts/control_center/app.py
@@ -1,0 +1,104 @@
+"""
+Orion-X Control Center — GTK Application + main window.
+
+Builds a Gtk.Notebook with one tab per section:
+  Network, Mesh, Comms, Awareness, IR Tools, Nebula AI, Auto-Healing
+
+The Nebula AI and Auto-Healing sections are PLACEHOLDERS in this slice.
+Phase 10 slices (W10-1 through W10-6) will replace the placeholder text
+with live runtime controls by importing from their own modules and
+swapping the section widget in the notebook.
+
+@decision DEC-PHASE10-005
+@title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+       sections define the plug-in surfaces for W10-1 through W10-6.
+@status accepted
+@rationale Phase 9 W9-2 locks the UI surface that Phase 10 slices plug
+  into.  The six sections (Network, Mesh, Comms, Awareness, IR, Nebula)
+  plus the Auto-Healing tab are the contractually-checked plug-in surfaces.
+  Nebula runtime code (ollama, llama.cpp, model staging) is explicitly
+  out of scope for W9-2 (see DEC-PHASE10-005) — no AI inference code
+  lives in this file.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale All shipped Python in Phase 9 / Phase 10 must use
+  `from __future__ import annotations` as the first import.  This
+  guarantees forward-compatible annotation evaluation under Python 3.9
+  (Debian Bullseye default) and enables ruff PEP-563 enforcement
+  (DEC-PHASE9-020).
+
+@decision DEC-PHASE9-020
+@title ruff check enforced on all new Python in Phase 9+
+@status accepted
+@rationale Static lint catches style and correctness issues before CI.
+  All new .py files must pass `ruff check` locally before commit.  The
+  unit test suite asserts this invariant mechanically.
+"""
+from __future__ import annotations
+
+import sys
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+from .sections import auto_healing, awareness, comms, ir, mesh, nebula, network  # noqa: E402
+
+
+class OrionXControlCenter(Gtk.Application):
+    """GTK Application shell for the Orion-X Control Center."""
+
+    APP_ID = "org.orionx.ControlCenter"
+
+    def __init__(self) -> None:
+        super().__init__(application_id=self.APP_ID)
+        self.connect("activate", self._on_activate)
+
+    # ------------------------------------------------------------------
+    # GTK Application lifecycle
+    # ------------------------------------------------------------------
+
+    def _on_activate(self, _app: Gtk.Application) -> None:
+        """Build and show the main window."""
+        win = Gtk.ApplicationWindow(application=self)
+        win.set_title("Orion-X Control Center")
+        win.set_default_size(700, 520)
+        win.set_icon_name("preferences-desktop")
+
+        notebook = Gtk.Notebook()
+        notebook.set_tab_pos(Gtk.PositionType.LEFT)
+
+        # Section definitions — order matches the mission brief.
+        # (tab_label, builder_function)
+        _sections = [
+            ("Network", network.build_section),
+            ("Mesh", mesh.build_section),
+            ("Comms", comms.build_section),
+            ("Awareness", awareness.build_section),
+            ("IR Tools", ir.build_section),
+            ("Nebula AI", nebula.build_section),
+            ("Auto-Healing", auto_healing.build_section),
+        ]
+
+        for tab_label, builder in _sections:
+            widget = builder()
+            scrolled = Gtk.ScrolledWindow()
+            scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+            scrolled.add(widget)
+            label = Gtk.Label(label=tab_label)
+            notebook.append_page(scrolled, label)
+
+        win.add(notebook)
+        win.show_all()
+
+
+def run_app(argv: list[str] | None = None) -> int:
+    """Entry point called by the orionx-control-center script.
+
+    Returns the GApplication exit status (0 on clean exit).
+    """
+    app = OrionXControlCenter()
+    return app.run(argv if argv is not None else sys.argv)

--- a/scripts/control_center/helpers/__init__.py
+++ b/scripts/control_center/helpers/__init__.py
@@ -1,0 +1,7 @@
+"""
+Orion-X Control Center — helpers package.
+
+Provides safe subprocess execution and periodic state polling utilities
+used by section modules and panel widgets.
+"""
+from __future__ import annotations

--- a/scripts/control_center/helpers/state_polling.py
+++ b/scripts/control_center/helpers/state_polling.py
@@ -1,0 +1,74 @@
+"""
+Orion-X Control Center — periodic state polling helpers.
+
+GLib.timeout_add is the GTK-native repeating-timer mechanism.  Every section
+that polls live data registers a poller here so the poll interval is a single
+tunable and the main-loop integration pattern is consistent.
+
+All data reads go through subprocess_runner (no shell=True).
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+try:
+    from gi.repository import GLib  # type: ignore[import]
+    _GLIB_AVAILABLE = True
+except ImportError:
+    _GLIB_AVAILABLE = False
+
+from .subprocess_runner import run_stdout
+
+# Default poll interval used by sections that do not specify one (ms).
+DEFAULT_POLL_MS = 5000
+
+
+def add_poll(
+    interval_ms: int,
+    callback: Callable[[], bool],
+) -> None:
+    """Register *callback* to fire every *interval_ms* milliseconds.
+
+    The callback must return True to keep repeating (GLib convention).
+    When GLib is unavailable (non-GTK test context), this is a no-op.
+    """
+    if _GLIB_AVAILABLE:
+        GLib.timeout_add(interval_ms, callback)
+
+
+# ---------------------------------------------------------------------------
+# Data-fetch helpers used by multiple sections
+# ---------------------------------------------------------------------------
+
+
+def get_active_connections() -> list[str]:
+    """Return list of active NM connection names via nmcli."""
+    raw = run_stdout(
+        ["nmcli", "-t", "-f", "NAME,STATE", "connection", "show", "--active"],
+        timeout=5,
+    )
+    if not raw:
+        return []
+    return [line.split(":")[0] for line in raw.splitlines() if line.strip()]
+
+
+def get_mesh_status() -> dict[str, str]:
+    """Return a dict with 'peers', 'status', 'raw' from orionx-mesh status.
+
+    Falls back gracefully when the mesh binary is absent.
+    """
+    raw = run_stdout(["sudo", "orionx-mesh", "status"], timeout=8)
+    return {"raw": raw, "status": "unknown" if not raw else "ok"}
+
+
+def get_matrix_service_state() -> str:
+    """Return systemctl is-active result for matrix-synapse-orionx.service."""
+    return run_stdout(
+        ["systemctl", "is-active", "matrix-synapse-orionx.service"],
+        timeout=5,
+    ) or "inactive"

--- a/scripts/control_center/helpers/subprocess_runner.py
+++ b/scripts/control_center/helpers/subprocess_runner.py
@@ -1,0 +1,73 @@
+"""
+Orion-X Control Center — safe subprocess wrappers.
+
+Rules enforced here:
+  - shell=True is NEVER used (DEC-PHASE9-019 / security hygiene).
+  - All commands are passed as a list of strings.
+  - Timeouts are mandatory so a stalled tool cannot hang the UI event loop.
+  - Stdout/stderr are captured; the caller decides what to display.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale All shipped Python in Phase 9 / Phase 10 must start with
+  `from __future__ import annotations` immediately after any shebang/docstring
+  to guarantee forward-compatible annotation evaluation under Python 3.9
+  (Debian Bullseye's default interpreter). This also enables ruff to enforce
+  PEP 563 consistently (DEC-PHASE9-020).
+"""
+from __future__ import annotations
+
+import subprocess
+from typing import Optional
+
+
+def run(
+    args: list[str],
+    timeout: int = 10,
+    input_text: Optional[str] = None,
+) -> tuple[int, str, str]:
+    """Run *args* safely (no shell=True) and return (returncode, stdout, stderr).
+
+    Parameters
+    ----------
+    args:
+        Command and arguments as a list; the first element is the executable.
+    timeout:
+        Seconds before the subprocess is killed.  Defaults to 10 s.
+    input_text:
+        Optional string piped to the process stdin.
+
+    Returns
+    -------
+    (returncode, stdout, stderr)
+        returncode is the process exit code; stdout and stderr are decoded
+        strings (empty string when nothing was written).
+    """
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            input=input_text,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError:
+        return 127, "", f"command not found: {args[0]}"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"command timed out after {timeout}s: {' '.join(args)}"
+    except OSError as exc:
+        return 1, "", f"OS error running {args[0]}: {exc}"
+
+
+def run_ok(args: list[str], timeout: int = 10) -> bool:
+    """Return True when *args* exits 0, False otherwise."""
+    rc, _out, _err = run(args, timeout=timeout)
+    return rc == 0
+
+
+def run_stdout(args: list[str], timeout: int = 10) -> str:
+    """Return stripped stdout of *args*, or empty string on failure."""
+    _rc, out, _err = run(args, timeout=timeout)
+    return out.strip()

--- a/scripts/control_center/orionx-control-center
+++ b/scripts/control_center/orionx-control-center
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Orion-X Control Center — executable entry script.
+
+Usage:
+  orionx-control-center [--help] [--version]
+
+This script is symlinked to /usr/bin/orionx-control-center by
+0700-orionx-setup.hook.chroot so it is on PATH in the live system.
+
+The script launches a GTK 3 window with six sections (Network, Mesh, Comms,
+Situational Awareness, IR Tools, Nebula AI) plus an Auto-Healing tab.
+
+@decision DEC-PHASE10-005
+@title Control Center ships ahead of Phase 10 Nebula AI
+@status accepted
+@rationale Phase 9 W9-2 locks the UI surface.  Nebula AI and Auto-Healing
+  sections are discoverable placeholders in this slice; Phase 10 slices
+  plug their runtime in without inventing new windows.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale All shipped Python in Phase 9 / Phase 10 must start with
+  `from __future__ import annotations` as the first import to guarantee
+  forward-compatible annotation evaluation under Python 3.9 (Debian
+  Bullseye default) and enable ruff PEP-563 enforcement (DEC-PHASE9-020).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+_VERSION = "2.0.0-rc5-w9-2"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="orionx-control-center",
+        description=(
+            "Orion-X Control Center — cyberdeck UX baseline.\n\n"
+            "Opens a GTK window with sections: Network, Mesh, Comms, "
+            "Situational Awareness, IR Tools, Nebula AI, Auto-Healing."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_VERSION}",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args, then launch the GTK application.
+
+    Returns
+    -------
+    int
+        Exit code (0 on success).
+    """
+    args_list = argv if argv is not None else sys.argv[1:]
+    _parse_args(args_list)
+
+    # Add the scripts/ directory to sys.path so `control_center` package
+    # is importable when the script is run directly as
+    # /usr/bin/orionx-control-center (symlink target is
+    # /opt/orionx/scripts/control_center/orionx-control-center).
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    scripts_dir = os.path.dirname(script_dir)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    from control_center.app import run_app  # noqa: PLC0415
+
+    return run_app(sys.argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/control_center/sections/__init__.py
+++ b/scripts/control_center/sections/__init__.py
@@ -1,0 +1,8 @@
+"""
+Orion-X Control Center — sections package.
+
+Each module in this package provides a build_section() factory function that
+returns a Gtk.Widget (typically a Gtk.Box or Gtk.Grid) ready to be embedded
+in the main window's notebook or stack.
+"""
+from __future__ import annotations

--- a/scripts/control_center/sections/auto_healing.py
+++ b/scripts/control_center/sections/auto_healing.py
@@ -1,0 +1,60 @@
+"""
+Orion-X Control Center — Auto-Healing tab (placeholder).
+
+The auto-healing playbook engine, per-class autonomy toggles, and
+reversible-action ledger land in W10-6.  This module renders the
+discoverable placeholder text that W10-6's implementer will replace
+with live tier controls.
+
+W10-6 implementer: replace the status text and add the per-class autonomy
+  toggle grid (off / propose / confirm / autonomous).
+
+@decision DEC-PHASE10-005
+@title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+       sections define the plug-in surfaces for W10-1 through W10-6.
+@status accepted
+@rationale Phase 9 W9-2 locks the UI surface; Phase 10 slices plug their
+  runtime into the clearly-labelled placeholder sections rather than
+  inventing new windows.  The exact placeholder text is contractually
+  checked by the W9-2 reviewer so W10-6 knows exactly where to land.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+# Placeholder text checked by W9-2 reviewer and referenced by W10-6
+# implementer.  The exact string "lands in W10-6" is asserted by
+# test_control_center.sh.
+PLACEHOLDER_TEXT = (
+    "Auto-Healing Playbooks\n\n"
+    "Status: not yet enabled (lands in W10-6)\n"
+    "Operator pre-approval per action class — Control Center will host\n"
+    "the per-class autonomy toggles (off / propose / confirm / autonomous)."
+)
+
+
+def build_section() -> Gtk.Widget:
+    """Return the Auto-Healing placeholder tab widget."""
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    box.set_border_width(12)
+
+    title = Gtk.Label()
+    title.set_markup("<b>Auto-Healing Playbooks</b>")
+    title.set_halign(Gtk.Align.START)
+    box.pack_start(title, False, False, 0)
+
+    placeholder = Gtk.Label(label=PLACEHOLDER_TEXT)
+    placeholder.set_halign(Gtk.Align.START)
+    placeholder.set_line_wrap(True)
+    placeholder.set_selectable(True)
+    box.pack_start(placeholder, False, False, 4)
+
+    return box

--- a/scripts/control_center/sections/awareness.py
+++ b/scripts/control_center/sections/awareness.py
@@ -1,0 +1,53 @@
+"""
+Orion-X Control Center — Situational Awareness section (placeholder).
+
+The detection daemon and threat-posture tier selector land in W10-5.
+This module renders the discoverable placeholder text that W10-5's
+implementer will replace with live tier controls.
+
+@decision DEC-PHASE10-005
+@title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+       sections define the plug-in surfaces for W10-1 through W10-6.
+@status accepted
+@rationale Phase 9 W9-2 locks the UI surface; Phase 10 slices plug their
+  runtime into the clearly-labelled placeholder sections rather than
+  inventing new windows.  The exact placeholder text is contractually
+  checked by the W9-2 reviewer so W10-5 knows exactly where to land.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+# Placeholder text checked by W9-2 reviewer and referenced by W10-5 implementer.
+PLACEHOLDER_TEXT = (
+    "Situational Awareness\n\n"
+    "Threat-posture: not yet enabled (lands in W10-5).\n"
+    "Tier selector will appear here."
+)
+
+
+def build_section() -> Gtk.Widget:
+    """Return the Situational Awareness placeholder section widget."""
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    box.set_border_width(12)
+
+    title = Gtk.Label()
+    title.set_markup("<b>Situational Awareness</b>")
+    title.set_halign(Gtk.Align.START)
+    box.pack_start(title, False, False, 0)
+
+    placeholder = Gtk.Label(label=PLACEHOLDER_TEXT)
+    placeholder.set_halign(Gtk.Align.START)
+    placeholder.set_line_wrap(True)
+    placeholder.set_selectable(True)
+    box.pack_start(placeholder, False, False, 4)
+
+    return box

--- a/scripts/control_center/sections/comms.py
+++ b/scripts/control_center/sections/comms.py
@@ -1,0 +1,71 @@
+"""
+Orion-X Control Center — Comms section.
+
+Displays matrix-synapse-orionx.service status and provides a button to open
+the Element-web chat interface.  The button is present-but-disabled when the
+service is inactive, with a tooltip explaining why.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+from ..helpers.state_polling import (  # noqa: E402
+    DEFAULT_POLL_MS,
+    add_poll,
+    get_matrix_service_state,
+)
+from ..helpers.subprocess_runner import run  # noqa: E402
+
+_MATRIX_CHAT_URL = "https://localhost:8008/"
+
+
+def build_section() -> Gtk.Widget:
+    """Return the Comms section widget."""
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    box.set_border_width(12)
+
+    title = Gtk.Label()
+    title.set_markup("<b>Comms (Matrix)</b>")
+    title.set_halign(Gtk.Align.START)
+    box.pack_start(title, False, False, 0)
+
+    status_label = Gtk.Label(label="Checking Matrix service…")
+    status_label.set_halign(Gtk.Align.START)
+    status_label.set_selectable(True)
+    box.pack_start(status_label, False, False, 4)
+
+    chat_btn = Gtk.Button(label="Open Matrix Chat")
+    chat_btn.set_tooltip_text(f"Open {_MATRIX_CHAT_URL} in the default browser")
+
+    def _open_chat(_widget: Gtk.Widget) -> None:
+        run(["xdg-open", _MATRIX_CHAT_URL], timeout=2)
+
+    chat_btn.connect("clicked", _open_chat)
+    box.pack_start(chat_btn, False, False, 0)
+
+    def _refresh_comms() -> bool:
+        state = get_matrix_service_state()
+        is_active = state == "active"
+        status_label.set_text(f"matrix-synapse-orionx: {state}")
+        chat_btn.set_sensitive(is_active)
+        if not is_active:
+            chat_btn.set_tooltip_text(
+                f"Matrix service is {state} — start it with: "
+                "sudo systemctl start matrix-synapse-orionx"
+            )
+        else:
+            chat_btn.set_tooltip_text(f"Open {_MATRIX_CHAT_URL} in the default browser")
+        return True
+
+    _refresh_comms()
+    add_poll(DEFAULT_POLL_MS, _refresh_comms)
+
+    return box

--- a/scripts/control_center/sections/ir.py
+++ b/scripts/control_center/sections/ir.py
@@ -1,0 +1,83 @@
+"""
+Orion-X Control Center — IR Tools section.
+
+Provides one-click launcher buttons for the six existing Orion-X tools.
+Each button opens xfce4-terminal with --hold so the operator can read output
+after the tool exits (matching the 0700 hook's .desktop Exec pattern).
+
+@decision DEC-PHASE9-001
+@title Terminal emulator: xfce4-terminal replaces lxterminal
+@status accepted
+@rationale lxterminal is NOT installed in the Orion-X ISO. All interactive
+  launcher Exec lines must use xfce4-terminal --hold. This module follows
+  the same pattern as the .desktop entries in 0700-orionx-setup.hook.chroot.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+from ..helpers.subprocess_runner import run  # noqa: E402
+
+# (label, command) pairs — command is the tool name already on PATH via /usr/bin/
+_IR_TOOLS: list[tuple[str, str]] = [
+    ("Artifact Analyzer", "artifact-analyzer.py"),
+    ("Storyboard Generator", "storyboard-gen.py"),
+    ("PCAP Analyzer", "pcap-analyzer.py"),
+    ("Lynis Security Audit", "run-lynis.sh"),
+    ("Download Samples", "download-samples.sh"),
+    ("Toggle Theme", "toggle-theme.sh"),
+]
+
+
+def build_section() -> Gtk.Widget:
+    """Return the IR Tools section widget."""
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    box.set_border_width(12)
+
+    title = Gtk.Label()
+    title.set_markup("<b>IR Tools</b>")
+    title.set_halign(Gtk.Align.START)
+    box.pack_start(title, False, False, 0)
+
+    desc = Gtk.Label(
+        label="Click a tool to open it in a terminal window (xfce4-terminal --hold)."
+    )
+    desc.set_halign(Gtk.Align.START)
+    desc.set_line_wrap(True)
+    box.pack_start(desc, False, False, 4)
+
+    grid = Gtk.Grid()
+    grid.set_column_spacing(8)
+    grid.set_row_spacing(6)
+    box.pack_start(grid, False, False, 0)
+
+    for idx, (label, cmd) in enumerate(_IR_TOOLS):
+        row = idx // 2
+        col = idx % 2
+        btn = Gtk.Button(label=label)
+        btn.set_tooltip_text(f"Launch: {cmd}")
+
+        # Capture cmd in the closure via default argument.
+        def _launch(_widget: Gtk.Widget, _cmd: str = cmd) -> None:
+            run(
+                [
+                    "xfce4-terminal",
+                    "--hold",
+                    "-e",
+                    f"bash -c '{_cmd}; exec bash'",
+                ],
+                timeout=2,
+            )
+
+        btn.connect("clicked", _launch)
+        grid.attach(btn, col, row, 1, 1)
+
+    return box

--- a/scripts/control_center/sections/mesh.py
+++ b/scripts/control_center/sections/mesh.py
@@ -1,0 +1,102 @@
+"""
+Orion-X Control Center — Mesh section.
+
+Shows live WireGuard mesh status (via `sudo orionx-mesh status`) and provides
+Start / Stop buttons that open xfce4-terminal windows so the operator can
+watch the join/leave output interactively.
+
+Polling: every DEFAULT_POLL_MS to keep peer count current.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+from ..helpers.state_polling import DEFAULT_POLL_MS, add_poll, get_mesh_status  # noqa: E402
+from ..helpers.subprocess_runner import run  # noqa: E402
+
+
+def build_section() -> Gtk.Widget:
+    """Return the Mesh section widget."""
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    box.set_border_width(12)
+
+    title = Gtk.Label()
+    title.set_markup("<b>Mesh (WireGuard P2P)</b>")
+    title.set_halign(Gtk.Align.START)
+    box.pack_start(title, False, False, 0)
+
+    status_label = Gtk.Label(label="Checking mesh status…")
+    status_label.set_halign(Gtk.Align.START)
+    status_label.set_line_wrap(True)
+    status_label.set_selectable(True)
+    box.pack_start(status_label, False, False, 4)
+
+    raw_label = Gtk.Label(label="")
+    raw_label.set_halign(Gtk.Align.START)
+    raw_label.set_line_wrap(True)
+    raw_label.set_selectable(True)
+    box.pack_start(raw_label, True, True, 0)
+
+    def _refresh_mesh() -> bool:
+        info = get_mesh_status()
+        raw = info.get("raw", "")
+        if raw:
+            status_label.set_text("Mesh status: running")
+            raw_label.set_text(raw[:400])  # cap display length
+        else:
+            status_label.set_text("Mesh status: not running or orionx-mesh unavailable")
+            raw_label.set_text("")
+        return True
+
+    _refresh_mesh()
+    add_poll(DEFAULT_POLL_MS, _refresh_mesh)
+
+    sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+    box.pack_start(sep, False, False, 4)
+
+    btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+    box.pack_start(btn_box, False, False, 0)
+
+    start_btn = Gtk.Button(label="Start Mesh")
+    start_btn.set_tooltip_text("Run: sudo orionx-mesh join (in terminal)")
+
+    def _start_mesh(_widget: Gtk.Widget) -> None:
+        run(
+            [
+                "xfce4-terminal",
+                "--hold",
+                "-e",
+                "bash -c 'sudo orionx-mesh join; exec bash'",
+            ],
+            timeout=2,
+        )
+
+    start_btn.connect("clicked", _start_mesh)
+    btn_box.pack_start(start_btn, False, False, 0)
+
+    stop_btn = Gtk.Button(label="Stop Mesh")
+    stop_btn.set_tooltip_text("Run: sudo orionx-mesh leave (in terminal)")
+
+    def _stop_mesh(_widget: Gtk.Widget) -> None:
+        run(
+            [
+                "xfce4-terminal",
+                "--hold",
+                "-e",
+                "bash -c 'sudo orionx-mesh leave; exec bash'",
+            ],
+            timeout=2,
+        )
+
+    stop_btn.connect("clicked", _stop_mesh)
+    btn_box.pack_start(stop_btn, False, False, 0)
+
+    return box

--- a/scripts/control_center/sections/nebula.py
+++ b/scripts/control_center/sections/nebula.py
@@ -1,0 +1,62 @@
+"""
+Orion-X Control Center — Nebula AI section (placeholder).
+
+The Nebula AI runtime (W10-1), chat interface (W10-2), and MCP tool server
+(W10-3) plug into this section.  The placeholder text below is the
+contractually-checked surface that those slices will replace.
+
+W10-1 implementer: replace the status line ("Runtime: not yet enabled…")
+  with live ollama daemon state once nebula-runtime.service is present.
+W10-2 implementer: replace the chat line with the GTK chat widget.
+W10-3 implementer: replace the tools line with the MCP tool-list widget.
+
+@decision DEC-PHASE10-005
+@title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+       sections define the plug-in surfaces for W10-1 through W10-6.
+@status accepted
+@rationale Phase 9 W9-2 locks the UI surface; Phase 10 slices plug their
+  runtime into the clearly-labelled placeholder sections rather than
+  inventing new windows.  The exact placeholder text is contractually
+  checked by the W9-2 reviewer so W10-1/W10-2/W10-3 know exactly where
+  to land.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+# Placeholder text checked by W9-2 reviewer and referenced by W10-1/2/3
+# implementers.  The exact strings "lands in W10-1", "coming in W10-2",
+# and "coming in W10-3" are asserted by test_control_center.sh.
+PLACEHOLDER_TEXT = (
+    "Nebula AI\n\n"
+    "Runtime: not yet enabled (lands in W10-1)\n"
+    "Chat:    coming in W10-2\n"
+    "Tools:   coming in W10-3"
+)
+
+
+def build_section() -> Gtk.Widget:
+    """Return the Nebula AI placeholder section widget."""
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    box.set_border_width(12)
+
+    title = Gtk.Label()
+    title.set_markup("<b>Nebula AI</b>")
+    title.set_halign(Gtk.Align.START)
+    box.pack_start(title, False, False, 0)
+
+    placeholder = Gtk.Label(label=PLACEHOLDER_TEXT)
+    placeholder.set_halign(Gtk.Align.START)
+    placeholder.set_line_wrap(True)
+    placeholder.set_selectable(True)
+    box.pack_start(placeholder, False, False, 4)
+
+    return box

--- a/scripts/control_center/sections/network.py
+++ b/scripts/control_center/sections/network.py
@@ -1,0 +1,75 @@
+"""
+Orion-X Control Center — Network section.
+
+Displays active NetworkManager connections and provides a button to launch
+nm-connection-editor (the GUI NM editor that ships with network-manager-gnome).
+
+Live data is polled every DEFAULT_POLL_MS via GLib.timeout_add so the list
+stays current without blocking the GTK main loop.
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See helpers/subprocess_runner.py for the full rationale.
+"""
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # type: ignore[import]  # noqa: E402
+
+from ..helpers.state_polling import DEFAULT_POLL_MS, add_poll, get_active_connections  # noqa: E402
+from ..helpers.subprocess_runner import run  # noqa: E402
+
+
+def build_section() -> Gtk.Widget:
+    """Return the Network section widget."""
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    box.set_border_width(12)
+
+    title = Gtk.Label()
+    title.set_markup("<b>Network</b>")
+    title.set_halign(Gtk.Align.START)
+    box.pack_start(title, False, False, 0)
+
+    status_label = Gtk.Label(label="Scanning connections…")
+    status_label.set_halign(Gtk.Align.START)
+    status_label.set_selectable(True)
+    box.pack_start(status_label, False, False, 4)
+
+    connections_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+    box.pack_start(connections_box, True, True, 0)
+
+    def _refresh_connections() -> bool:
+        """Poll active NM connections; update the UI.  Returns True to repeat."""
+        conns = get_active_connections()
+        for child in connections_box.get_children():
+            connections_box.remove(child)
+        if conns:
+            status_label.set_text(f"{len(conns)} active connection(s):")
+            for name in conns:
+                row = Gtk.Label(label=f"  • {name}")
+                row.set_halign(Gtk.Align.START)
+                connections_box.pack_start(row, False, False, 0)
+        else:
+            status_label.set_text("No active connections")
+        connections_box.show_all()
+        return True  # keep polling
+
+    _refresh_connections()
+    add_poll(DEFAULT_POLL_MS, _refresh_connections)
+
+    sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+    box.pack_start(sep, False, False, 4)
+
+    btn = Gtk.Button(label="Open Network Manager")
+    btn.set_tooltip_text("Launch nm-connection-editor to manage connections")
+
+    def _open_nm(_widget: Gtk.Widget) -> None:
+        run(["nm-connection-editor"], timeout=2)
+
+    btn.connect("clicked", _open_nm)
+    box.pack_start(btn, False, False, 0)
+
+    return box

--- a/scripts/control_center/widgets/clients-count.py
+++ b/scripts/control_center/widgets/clients-count.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Orion-X XFCE panel widget — clients count (xfce4-genmon-plugin format).
+
+Placeholder: the detection daemon (W10-5) will replace the "?" output
+with a live count of observed network clients.
+
+Output: "👥 ?" until W10-5.
+
+@decision DEC-PHASE10-005
+@title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+       widgets define the panel surfaces for W10-5.
+@status accepted
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See control_center/helpers/subprocess_runner.py for full rationale.
+"""
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    # W10-5 implementer: replace this with live client count from the
+    # detection daemon socket or state file.
+    print("\U0001f465 ?")  # 👥 ?
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/scripts/control_center/widgets/mesh-status.py
+++ b/scripts/control_center/widgets/mesh-status.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Orion-X XFCE panel widget — mesh status (xfce4-genmon-plugin format).
+
+Outputs a single line to stdout on each invocation:
+  "🔗 3p"  — mesh running, 3 peers visible
+  "🔗 0p"  — mesh interface up but no peers
+  "—"      — mesh not running or orionx-mesh not on PATH
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See control_center/helpers/subprocess_runner.py for full rationale.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _get_peer_count() -> int | None:
+    """Return WireGuard peer count from orionx-mesh status, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["sudo", "orionx-mesh", "status"],
+            capture_output=True,
+            text=True,
+            timeout=8,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        # Count "peer:" lines in wg show output embedded in status output.
+        peer_count = sum(
+            1 for line in result.stdout.splitlines() if line.strip().startswith("peer:")
+        )
+        return peer_count
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def main() -> None:
+    count = _get_peer_count()
+    if count is None:
+        print("—")  # em-dash — mesh not running
+    else:
+        print(f"\U0001f517 {count}p")  # 🔗 Np
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/scripts/control_center/widgets/net-status.py
+++ b/scripts/control_center/widgets/net-status.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Orion-X XFCE panel widget — network status (xfce4-genmon-plugin format).
+
+Outputs a single line to stdout on each invocation.  xfce4-genmon-plugin
+calls this script on its own schedule (configure via genmon plugin settings).
+
+Output format: "▲ wlan0" (up with interface name) or "▼ down" (no NM conns).
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See control_center/helpers/subprocess_runner.py for full rationale.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _get_active_iface() -> str:
+    """Return the first active NM connection name, or empty string."""
+    try:
+        result = subprocess.run(
+            ["nmcli", "-t", "-f", "NAME,STATE", "connection", "show", "--active"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if len(parts) >= 2 and parts[1].strip():
+                return parts[0].strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return ""
+
+
+def main() -> None:
+    iface = _get_active_iface()
+    if iface:
+        print(f"▲ {iface}")
+    else:
+        print("▼ down")
+
+
+if __name__ == "__main__":
+    # Allow running from any directory without path manipulation.
+    main()
+    sys.exit(0)

--- a/scripts/control_center/widgets/scans-count.py
+++ b/scripts/control_center/widgets/scans-count.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Orion-X XFCE panel widget — scans count (xfce4-genmon-plugin format).
+
+Placeholder: the detection daemon (W10-5) will replace the "?" output
+with a live count of active/recent scans observed.
+
+Output: "🔍 ?" until W10-5.
+
+@decision DEC-PHASE10-005
+@title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+       widgets define the panel surfaces for W10-5.
+@status accepted
+
+@decision DEC-PHASE9-019
+@title Bullseye Python 3.9 + PEP-563 (from __future__ import annotations)
+@status accepted
+@rationale See control_center/helpers/subprocess_runner.py for full rationale.
+"""
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    # W10-5 implementer: replace this with live scan count from the
+    # detection daemon socket or state file.
+    print("\U0001f50d ?")  # 🔍 ?
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/tests/integration/test-iso-content-presence.sh
+++ b/tests/integration/test-iso-content-presence.sh
@@ -468,6 +468,104 @@ else
 fi
 
 # ===========================================================================
+# 14. W9-2: Orion-X Control Center — GTK app + GTK/genmon packages staged
+#
+# @decision DEC-PHASE10-005
+# @title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+#        sections define the plug-in surfaces for W10-1 through W10-6.
+# @status accepted
+# @rationale stage_application_content rsyncs scripts/ → /opt/orionx/scripts/
+#   so the control_center/ module lands in the ISO automatically. The 0700
+#   hook creates the /usr/bin/orionx-control-center symlink and copies the
+#   .desktop launcher. Package presence is asserted via dpkg/status (same
+#   pattern as section 8). DEC-PHASE9-014 pipefail guard applied to any
+#   grep-count pipeline.
+# ===========================================================================
+section "14. W9-2: Control Center — GTK app + GTK/genmon packages staged"
+
+# (a) Entry script staged and executable
+if [[ -f "$SQF/opt/orionx/scripts/control_center/orionx-control-center" ]]; then
+    pass "/opt/orionx/scripts/control_center/orionx-control-center staged"
+else
+    fail "/opt/orionx/scripts/control_center/orionx-control-center staged" \
+         "stage_application_content must rsync scripts/control_center/ into the ISO"
+fi
+
+if [[ -x "$SQF/opt/orionx/scripts/control_center/orionx-control-center" ]]; then
+    pass "/opt/orionx/scripts/control_center/orionx-control-center is executable"
+else
+    fail "/opt/orionx/scripts/control_center/orionx-control-center is executable" \
+         "0700 hook sets chmod 755 on scripts/ files — check hook execution"
+fi
+
+# (b) Python module present (app.py + at least one section file)
+if [[ -f "$SQF/opt/orionx/scripts/control_center/app.py" ]]; then
+    pass "/opt/orionx/scripts/control_center/app.py staged"
+else
+    fail "/opt/orionx/scripts/control_center/app.py staged" \
+         "control_center/ Python package must be staged via stage_application_content"
+fi
+
+if [[ -f "$SQF/opt/orionx/scripts/control_center/sections/nebula.py" ]]; then
+    pass "/opt/orionx/scripts/control_center/sections/nebula.py staged"
+else
+    fail "/opt/orionx/scripts/control_center/sections/nebula.py staged" \
+         "control_center/sections/ not fully staged — check rsync in stage_application_content"
+fi
+
+# (c) /usr/bin/orionx-control-center symlink present (created by 0700 hook)
+if [[ -L "$SQF/usr/bin/orionx-control-center" ]]; then
+    pass "/usr/bin/orionx-control-center symlink present (0700 hook)"
+elif [[ -f "$SQF/usr/bin/orionx-control-center" ]]; then
+    pass "/usr/bin/orionx-control-center present (as regular file, 0700 hook)"
+else
+    fail "/usr/bin/orionx-control-center symlink present" \
+         "0700-orionx-setup.hook.chroot SCRIPT_MAP must include orionx-control-center"
+fi
+
+# (d) .desktop launcher present
+if [[ -f "$SQF/usr/share/applications/orionx-control-center.desktop" ]]; then
+    pass "/usr/share/applications/orionx-control-center.desktop present"
+else
+    fail "/usr/share/applications/orionx-control-center.desktop present" \
+         "0700 hook must create /usr/share/applications/orionx-control-center.desktop"
+fi
+
+# (e) .desktop Exec line must point to /usr/bin/orionx-control-center
+#     (DEC-PHASE9-006 invariant: no lxterminal, direct GTK executable)
+CONTROL_DESKTOP="$SQF/usr/share/applications/orionx-control-center.desktop"
+if [[ -f "$CONTROL_DESKTOP" ]]; then
+    if grep -qE "^Exec=/usr/bin/orionx-control-center" "$CONTROL_DESKTOP" 2>/dev/null; then
+        pass ".desktop Exec line is Exec=/usr/bin/orionx-control-center (DEC-PHASE9-006)"
+    else
+        fail ".desktop Exec line is Exec=/usr/bin/orionx-control-center" \
+             "Check orionx-control-center.desktop Exec line — must be direct GTK exec (no lxterminal)"
+    fi
+    # DEC-PHASE9-006: no lxterminal in the Exec line
+    # || true: DEC-PHASE9-014 — grep exits 1 on no-match; under pipefail this kills
+    # the script before the count is tested. Zero matches is the desired state.
+    LXTERM_IN_DESKTOP="$(grep -c "lxterminal" "$CONTROL_DESKTOP" 2>/dev/null || true)"
+    if [[ "$LXTERM_IN_DESKTOP" -eq 0 ]]; then
+        pass ".desktop has zero lxterminal references (DEC-PHASE9-006 invariant)"
+    else
+        fail ".desktop has zero lxterminal references" \
+             "Found $LXTERM_IN_DESKTOP lxterminal reference(s) — violates DEC-PHASE9-006"
+    fi
+fi
+
+# (f) GTK / GI / genmon packages installed in chroot dpkg
+#     Same dpkg/status + binary-fallback pattern as section 8. DEC-PHASE9-014
+#     pipefail guard not needed here because we use grep -q (no pipe).
+for gtk_pkg in python3-gi gir1.2-gtk-3.0 gir1.2-glib-2.0 xfce4-genmon-plugin; do
+    if [[ -f "$DPKG_STATUS" ]] && grep -q "^Package: ${gtk_pkg}$" "$DPKG_STATUS" 2>/dev/null; then
+        pass "package installed in chroot: $gtk_pkg (dpkg status, DEC-PHASE10-005)"
+    else
+        fail "package installed in chroot: $gtk_pkg" \
+             "Check orionx.list.chroot includes $gtk_pkg (W9-2 GTK dependency)"
+    fi
+done
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/integration/test-iso-hooks-applied.sh
+++ b/tests/integration/test-iso-hooks-applied.sh
@@ -284,6 +284,75 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
+# rc5 W9-2 static checks: orionx-control-center .desktop + symlink in 0700 hook
+#
+# @decision DEC-PHASE10-005
+# @title Control Center ships ahead of Phase 10 Nebula AI; hook wiring
+#        is asserted here as a static gate that does not require a built ISO.
+# @status accepted
+# @rationale The 0700 hook is the single authority for /usr/bin symlinks
+#   (0700_hook_path_symlinks_authority) and .desktop launchers
+#   (0700_hook_desktop_launcher_authority). These checks confirm both wires
+#   are present in the hook source so a future refactor cannot silently
+#   remove them. DEC-PHASE9-006 invariant: no lxterminal in any Exec line
+#   of the orionx-control-center .desktop (GTK app, no terminal wrapper).
+#   Comment-filtering matches the approach in the rc4 static checks above:
+#   `grep -v '^\s*#' | grep -c lxterminal` so @decision documentation that
+#   mentions lxterminal does not false-positive.
+# ---------------------------------------------------------------------------
+echo "--- rc5 W9-2 static checks: orionx-control-center hook wiring ---"
+echo ""
+
+if [[ -f "$HOOK_0700" ]]; then
+    # (a) .desktop launcher present: /usr/share/applications/orionx-control-center.desktop
+    if grep -q "orionx-control-center.desktop" "$HOOK_0700"; then
+        pass "W9-2: 0700 hook creates /usr/share/applications/orionx-control-center.desktop"
+    else
+        fail "W9-2: 0700 hook creates /usr/share/applications/orionx-control-center.desktop"
+    fi
+
+    # (b) .desktop Exec line is NOT lxterminal (DEC-PHASE9-006 invariant).
+    #     Filter comment lines first to avoid false-positives from @decision
+    #     documentation that mentions lxterminal for historical context.
+    LXTERM_CONTROL="$(grep -v '^\s*#' "$HOOK_0700" | grep -c "lxterminal" || true)"
+    if [[ "$LXTERM_CONTROL" -eq 0 ]]; then
+        pass "W9-2: orionx-control-center .desktop does NOT use lxterminal (DEC-PHASE9-006)"
+    else
+        fail "W9-2: orionx-control-center .desktop does NOT use lxterminal" \
+             "Found $LXTERM_CONTROL functional lxterminal reference(s) — DEC-PHASE9-006 violated"
+    fi
+
+    # (c) Exec line for orionx-control-center.desktop uses absolute path
+    if grep -q "Exec=/usr/bin/orionx-control-center" "$HOOK_0700" 2>/dev/null; then
+        pass "W9-2: orionx-control-center.desktop Exec=/usr/bin/orionx-control-center (DEC-PHASE9-006)"
+    else
+        fail "W9-2: orionx-control-center.desktop Exec=/usr/bin/orionx-control-center" \
+             "0700 hook must emit Exec=/usr/bin/orionx-control-center in the .desktop block"
+    fi
+
+    # (d) /usr/bin/orionx-control-center symlink entry present in SCRIPT_MAP
+    if grep -q '"orionx-control-center"' "$HOOK_0700" 2>/dev/null; then
+        pass "W9-2: orionx-control-center present in SCRIPT_MAP symlink loop"
+    else
+        fail "W9-2: orionx-control-center present in SCRIPT_MAP symlink loop" \
+             "0700 hook SCRIPT_MAP must include orionx-control-center → /opt/orionx/scripts/control_center/"
+    fi
+
+    # (e) .desktop file staged in includes.chroot (source-tree presence check)
+    DESKTOP_SRC="$REPO_ROOT/iso/config/includes.chroot/usr/share/applications/orionx-control-center.desktop"
+    if [[ -f "$DESKTOP_SRC" ]]; then
+        pass "W9-2: iso/config/includes.chroot/usr/share/applications/orionx-control-center.desktop staged"
+    else
+        fail "W9-2: iso/config/includes.chroot/usr/share/applications/orionx-control-center.desktop staged" \
+             "Static .desktop file must be present in includes.chroot for live-build to copy into chroot"
+    fi
+else
+    skip "W9-2: orionx-control-center hook wiring checks" "hook file not found: $HOOK_0700"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo "================================================================"

--- a/tests/unit/test_build_iso.sh
+++ b/tests/unit/test_build_iso.sh
@@ -521,6 +521,56 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
+# T23: GTK / PyGObject / genmon packages in orionx.list.chroot (W9-2)
+#
+# @decision DEC-PHASE10-005: Control Center ships ahead of Phase 10 Nebula AI;
+# these packages must be present before any Phase 10 slice lands.
+# ---------------------------------------------------------------------------
+echo "[T23] GTK / PyGObject / genmon packages in orionx.list.chroot (W9-2)"
+PKG_LIST_GTK="$REPO_ROOT/iso/config/package-lists/orionx.list.chroot"
+if [[ -f "$PKG_LIST_GTK" ]]; then
+    for gtk_pkg in python3-gi gir1.2-gtk-3.0 gir1.2-glib-2.0 xfce4-genmon-plugin; do
+        if grep -qE "^${gtk_pkg}$" "$PKG_LIST_GTK"; then
+            pass "$gtk_pkg present as uncommented entry in orionx.list.chroot (W9-2)"
+        else
+            fail "$gtk_pkg present as uncommented entry in orionx.list.chroot" \
+                 "W9-2 requires $gtk_pkg for the GTK Control Center and panel widgets"
+        fi
+    done
+    # Decision annotation must be present
+    if grep -q "DEC-PHASE10-005" "$PKG_LIST_GTK"; then
+        pass "DEC-PHASE10-005 annotation present alongside GTK packages in orionx.list.chroot"
+    else
+        fail "DEC-PHASE10-005 annotation present alongside GTK packages" \
+             "W9-2 requires @decision DEC-PHASE10-005 comment near the GTK package block"
+    fi
+else
+    fail "GTK package check: orionx.list.chroot not found at $PKG_LIST_GTK"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# T24: scripts/control_center/orionx-control-center entry script exists (W9-2)
+#
+# stage_application_content rsyncs scripts/ — the entry script must exist
+# in the source tree so it gets staged into the ISO automatically.
+# ---------------------------------------------------------------------------
+echo "[T24] scripts/control_center/orionx-control-center exists and is executable (W9-2)"
+CC_ENTRY="$REPO_ROOT/scripts/control_center/orionx-control-center"
+run_test "scripts/control_center/orionx-control-center exists" "[[ -f '$CC_ENTRY' ]]"
+run_test "scripts/control_center/orionx-control-center is executable" "[[ -x '$CC_ENTRY' ]]"
+if [[ -f "$CC_ENTRY" ]]; then
+    CC_SHEBANG="$(head -n1 "$CC_ENTRY")"
+    if [[ "$CC_SHEBANG" == "#!/usr/bin/env python3" ]]; then
+        pass "scripts/control_center/orionx-control-center shebang is #!/usr/bin/env python3"
+    else
+        fail "scripts/control_center/orionx-control-center shebang is #!/usr/bin/env python3" \
+             "Got: $CC_SHEBANG"
+    fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo "================================================================"

--- a/tests/unit/test_control_center.sh
+++ b/tests/unit/test_control_center.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Unit tests for scripts/control_center/ (W9-2 GTK Control Center)
+#
+# Validates structural and content properties of the Control Center Python
+# package without requiring a GTK display, a running ISO, or chroot access.
+#
+# @decision DEC-PHASE9-019
+# @title Bullseye Python 3.9 + PEP-563 test gate
+# @status accepted
+# @rationale Every new .py file must start with `from __future__ import
+#   annotations` as the first import.  This test asserts that invariant
+#   mechanically so regressions are caught before CI.
+#
+# @decision DEC-PHASE9-020
+# @title ruff check enforced on all new Python in Phase 9+
+# @status accepted
+# @rationale ruff is invoked here when available; the test skips gracefully
+#   when ruff is absent so macOS dev machines without ruff stay unblocked,
+#   but CI (which has ruff) will fail on any lint regression.
+#
+# @decision DEC-PHASE10-005
+# @title Control Center ships ahead of Phase 10 Nebula AI; placeholder
+#        sections define the plug-in surfaces for W10-1 through W10-6.
+# @status accepted
+# @rationale The Nebula ("lands in W10-1") and Auto-Healing ("lands in W10-6")
+#   placeholder texts are asserted here so the W9-2 reviewer can confirm the
+#   plug-in surfaces exist and W10-1..W10-6 implementers know exactly where to
+#   land their runtime code.
+#
+# Production sequence:
+#   1. stage_application_content rsyncs scripts/ → includes.chroot/opt/orionx/scripts/
+#   2. live-build copies includes.chroot/ into the chroot filesystem
+#   3. 0700-orionx-setup.hook.chroot symlinks orionx-control-center → /usr/bin/
+#   4. Operator clicks .desktop → /usr/bin/orionx-control-center executes → GTK window
+#
+# Usage: bash tests/unit/test_control_center.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+CC_DIR="$REPO_ROOT/scripts/control_center"
+ENTRY="$CC_DIR/orionx-control-center"
+
+# ---------------------------------------------------------------------------
+# Test counters (((VAR+=1)) avoids set -e firing on zero-result arithmetic)
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+SKIP=0
+
+if [[ -t 1 ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[0;33m'
+    NC=$'\033[0m'
+else
+    RED="" GREEN="" YELLOW="" NC=""
+fi
+
+pass() { ((PASS+=1)); echo "${GREEN}  PASS${NC}: $1"; }
+fail() {
+    ((FAIL+=1))
+    echo "${RED}  FAIL${NC}: $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+skip() { ((SKIP+=1)); echo "${YELLOW}  SKIP${NC}: $1 — $2"; }
+section() { echo ""; echo "--- $1 ---"; }
+
+echo "=== W9-2: Control Center — Structural Unit Tests ==="
+
+# ===========================================================================
+# 1. Entry script presence, permissions, shebang
+# ===========================================================================
+section "Entry script: orionx-control-center"
+
+if [[ -f "$ENTRY" ]]; then
+    pass "orionx-control-center exists"
+else
+    fail "orionx-control-center exists" "Not found: $ENTRY"
+    echo "FATAL: entry script missing — cannot continue."
+    exit 1
+fi
+
+if [[ -x "$ENTRY" ]]; then
+    pass "orionx-control-center is executable"
+else
+    fail "orionx-control-center is executable" "Run: chmod +x $ENTRY"
+fi
+
+SHEBANG="$(head -n1 "$ENTRY")"
+if [[ "$SHEBANG" == "#!/usr/bin/env python3" ]]; then
+    pass "shebang is #!/usr/bin/env python3"
+else
+    fail "shebang is #!/usr/bin/env python3" "Got: $SHEBANG"
+fi
+
+# ===========================================================================
+# 2. Python compile check on entry script and every .py in control_center/
+# ===========================================================================
+section "Python compile check (py_compile)"
+
+if python3 -m py_compile "$ENTRY" 2>&1; then
+    pass "py_compile: orionx-control-center"
+else
+    fail "py_compile: orionx-control-center"
+fi
+
+while IFS= read -r -d '' pyfile; do
+    relpath="${pyfile#"$REPO_ROOT/"}"
+    if python3 -m py_compile "$pyfile" 2>&1; then
+        pass "py_compile: $relpath"
+    else
+        fail "py_compile: $relpath"
+    fi
+done < <(find "$CC_DIR" -name "*.py" -print0 | sort -z)
+
+# ===========================================================================
+# 3. from __future__ import annotations — first import in EVERY .py
+#    (DEC-PHASE9-019 hard invariant)
+# ===========================================================================
+section "from __future__ import annotations (DEC-PHASE9-019)"
+
+check_annotations() {
+    local file="$1"
+    local relpath="${file#"$REPO_ROOT/"}"
+    # Strip the shebang line (if any) and blank/comment lines, then check
+    # whether the first import-looking line is `from __future__ import annotations`.
+    local first_import
+    first_import="$(grep -v '^\s*#' "$file" | grep -v '^\s*$' | grep -E '^\s*(import |from )' | head -n1)"
+    if [[ "$first_import" == *"from __future__ import annotations"* ]]; then
+        pass "__future__ annotations first: $relpath"
+    else
+        fail "__future__ annotations first: $relpath" \
+             "Expected 'from __future__ import annotations' but got: $first_import"
+    fi
+}
+
+check_annotations "$ENTRY"
+while IFS= read -r -d '' pyfile; do
+    check_annotations "$pyfile"
+done < <(find "$CC_DIR" -name "*.py" -print0 | sort -z)
+
+# ===========================================================================
+# 4. --help exits 0
+# ===========================================================================
+section "--help exits 0"
+
+if python3 "$ENTRY" --help >/dev/null 2>&1; then
+    pass "orionx-control-center --help exits 0"
+else
+    fail "orionx-control-center --help exits 0"
+fi
+
+# ===========================================================================
+# 5. Nebula placeholder text contains "lands in W10-1" (DEC-PHASE10-005)
+# ===========================================================================
+section "Nebula placeholder text (DEC-PHASE10-005)"
+
+NEBULA_PY="$CC_DIR/sections/nebula.py"
+if [[ -f "$NEBULA_PY" ]]; then
+    if grep -q "lands in W10-1" "$NEBULA_PY"; then
+        pass "nebula.py contains 'lands in W10-1' placeholder (W10-1 plug-in surface)"
+    else
+        fail "nebula.py contains 'lands in W10-1' placeholder" \
+             "W10-1 implementer needs this text to locate the correct section"
+    fi
+    if grep -q "coming in W10-2" "$NEBULA_PY"; then
+        pass "nebula.py contains 'coming in W10-2' (W10-2 chat plug-in surface)"
+    else
+        fail "nebula.py contains 'coming in W10-2'" \
+             "W10-2 implementer needs this text to locate the correct section"
+    fi
+    if grep -q "coming in W10-3" "$NEBULA_PY"; then
+        pass "nebula.py contains 'coming in W10-3' (W10-3 MCP plug-in surface)"
+    else
+        fail "nebula.py contains 'coming in W10-3'" \
+             "W10-3 implementer needs this text to locate the correct section"
+    fi
+else
+    fail "sections/nebula.py exists" "Not found: $NEBULA_PY"
+fi
+
+# ===========================================================================
+# 6. Auto-Healing placeholder text contains "lands in W10-6" (DEC-PHASE10-005)
+# ===========================================================================
+section "Auto-Healing placeholder text (DEC-PHASE10-005)"
+
+AUTO_PY="$CC_DIR/sections/auto_healing.py"
+if [[ -f "$AUTO_PY" ]]; then
+    if grep -q "lands in W10-6" "$AUTO_PY"; then
+        pass "auto_healing.py contains 'lands in W10-6' (W10-6 plug-in surface)"
+    else
+        fail "auto_healing.py contains 'lands in W10-6'" \
+             "W10-6 implementer needs this text to locate the correct tab"
+    fi
+else
+    fail "sections/auto_healing.py exists" "Not found: $AUTO_PY"
+fi
+
+# ===========================================================================
+# 7. Six sections discoverable (directory listing of sections/)
+# ===========================================================================
+section "6 sections discoverable in sections/"
+
+SECTIONS_DIR="$CC_DIR/sections"
+EXPECTED_SECTIONS=(
+    "network.py"
+    "mesh.py"
+    "comms.py"
+    "awareness.py"
+    "ir.py"
+    "nebula.py"
+)
+
+for sec in "${EXPECTED_SECTIONS[@]}"; do
+    if [[ -f "$SECTIONS_DIR/$sec" ]]; then
+        pass "section present: $sec"
+    else
+        fail "section present: $sec" "Not found: $SECTIONS_DIR/$sec"
+    fi
+done
+
+# Auto-Healing is a TAB (separate from the 6 main sections)
+if [[ -f "$SECTIONS_DIR/auto_healing.py" ]]; then
+    pass "Auto-Healing tab module present: auto_healing.py"
+else
+    fail "Auto-Healing tab module present: auto_healing.py"
+fi
+
+# ===========================================================================
+# 8. No third-party imports (stdlib + gi.repository only)
+#    Scan for any `import X` or `from X import` where X is not in the
+#    allowed set (stdlib names or 'gi').
+# ===========================================================================
+section "No third-party imports (stdlib + gi.repository only)"
+
+_ALLOWED_PREFIXES="(os|sys|subprocess|typing|argparse|gi|__future__|control_center|\\.\\.)"
+
+_found_violation=0
+while IFS= read -r -d '' pyfile; do
+    # Extract import lines, strip comments and blank lines
+    while IFS= read -r line; do
+        # Normalise and extract the top-level module name
+        if [[ "$line" =~ ^from[[:space:]]+([a-zA-Z_][a-zA-Z0-9_.]*) ]]; then
+            module="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ ^import[[:space:]]+([a-zA-Z_][a-zA-Z0-9_.]*) ]]; then
+            module="${BASH_REMATCH[1]}"
+        else
+            continue
+        fi
+        # Relative imports (start with dot) are always internal — allowed
+        if [[ "$line" == from\ .* ]]; then
+            continue
+        fi
+        top="${module%%.*}"
+        # Check against allowed prefixes
+        if ! [[ "$top" =~ ^(os|sys|subprocess|typing|argparse|gi|__future__)$ ]]; then
+            fail "no third-party import: ${pyfile#"$REPO_ROOT/"} imports '$top'" \
+                 "Only stdlib + gi.repository allowed in shipped Python"
+            _found_violation=1
+        fi
+    done < <(grep -E '^\s*(import |from )' "$pyfile" | grep -v '^\s*#')
+done < <(find "$CC_DIR" -name "*.py" -print0 | sort -z)
+
+if [[ "$_found_violation" -eq 0 ]]; then
+    pass "no third-party imports found in scripts/control_center/"
+fi
+
+# ===========================================================================
+# 9. @decision DEC-PHASE10-005 annotation present in app.py
+# ===========================================================================
+section "@decision DEC-PHASE10-005 in app.py"
+
+APP_PY="$CC_DIR/app.py"
+if [[ -f "$APP_PY" ]]; then
+    if grep -q "DEC-PHASE10-005" "$APP_PY"; then
+        pass "@decision DEC-PHASE10-005 present in app.py"
+    else
+        fail "@decision DEC-PHASE10-005 present in app.py" \
+             "Required decision annotation missing from app.py module docstring"
+    fi
+else
+    fail "app.py exists" "Not found: $APP_PY"
+fi
+
+# ===========================================================================
+# 10. ruff check (DEC-PHASE9-020) — skip gracefully when ruff not installed
+# ===========================================================================
+section "ruff check (DEC-PHASE9-020)"
+
+if command -v ruff >/dev/null 2>&1; then
+    if ruff check "$CC_DIR/" 2>&1; then
+        pass "ruff check scripts/control_center/ passes clean"
+    else
+        fail "ruff check scripts/control_center/ passes clean" \
+             "Fix all ruff errors before committing (DEC-PHASE9-020)"
+    fi
+else
+    skip "ruff check" "ruff not installed — install with: pip3 install ruff"
+fi
+
+# ===========================================================================
+# 11. Compound-interaction: production sequence coherence
+#     Verify that the package is wired consistently end-to-end:
+#     a) app.py imports all 6 sections + auto_healing
+#     b) orionx-control-center calls main() which calls run_app()
+#     c) helpers package is importable from sections (relative imports)
+#     d) widgets directory exists with 4 scripts
+# ===========================================================================
+section "Compound-interaction: package wiring coherence"
+
+# a) app.py imports all section modules
+if grep -q "from .sections import" "$APP_PY" 2>/dev/null; then
+    IMPORTS_LINE="$(grep 'from .sections import' "$APP_PY")"
+    for sec_mod in network mesh comms awareness ir nebula auto_healing; do
+        if [[ "$IMPORTS_LINE" == *"$sec_mod"* ]]; then
+            pass "app.py imports section module: $sec_mod"
+        else
+            fail "app.py imports section module: $sec_mod" \
+                 "Section module not in app.py import line: $IMPORTS_LINE"
+        fi
+    done
+else
+    fail "app.py has 'from .sections import' line"
+fi
+
+# b) entry script calls main()
+if grep -q "main(" "$ENTRY" 2>/dev/null; then
+    pass "orionx-control-center calls main()"
+else
+    fail "orionx-control-center calls main()"
+fi
+
+# c) helpers __init__.py exists (importable package marker)
+if [[ -f "$CC_DIR/helpers/__init__.py" ]]; then
+    pass "helpers/__init__.py present (package marker)"
+else
+    fail "helpers/__init__.py present (package marker)"
+fi
+
+# d) 4 widget scripts present
+WIDGETS_DIR="$CC_DIR/widgets"
+EXPECTED_WIDGETS=(
+    "net-status.py"
+    "mesh-status.py"
+    "clients-count.py"
+    "scans-count.py"
+)
+for w in "${EXPECTED_WIDGETS[@]}"; do
+    if [[ -f "$WIDGETS_DIR/$w" ]]; then
+        pass "widget present: $w"
+    else
+        fail "widget present: $w" "Not found: $WIDGETS_DIR/$w"
+    fi
+done
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo ""
+echo "==========================================="
+TOTAL=$(( PASS + FAIL + SKIP ))
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped (total: $TOTAL)"
+echo "==========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/unit/test_orionx_setup_hook_unit.sh
+++ b/tests/unit/test_orionx_setup_hook_unit.sh
@@ -147,9 +147,9 @@ else
 fi
 
 # ===========================================================================
-# 4. PATH symlinks for all 9 Orion-X scripts (W9-2a: +pcap-analyzer.py)
+# 4. PATH symlinks for all 10 Orion-X scripts (W9-2: +orionx-control-center)
 # ===========================================================================
-section "PATH symlinks for all 9 scripts (W9-2a: pcap-analyzer.py added)"
+section "PATH symlinks for all 10 scripts (W9-2: orionx-control-center added)"
 
 EXPECTED_SCRIPTS=(
     "orionx-mesh"
@@ -161,6 +161,7 @@ EXPECTED_SCRIPTS=(
     "run-lynis.sh"
     "download-samples.sh"
     "pcap-analyzer.py"
+    "orionx-control-center"
 )
 
 for script in "${EXPECTED_SCRIPTS[@]}"; do
@@ -188,12 +189,30 @@ else
          "SCRIPT_MAP entry missing or wrong target for pcap-analyzer.py"
 fi
 
+# W9-2: orionx-control-center maps to the correct target path (10th entry)
+if [[ "$HOOK_CONTENT" == *'["orionx-control-center"]="/opt/orionx/scripts/control_center/orionx-control-center"'* ]]; then
+    pass "orionx-control-center maps to /opt/orionx/scripts/control_center/orionx-control-center (W9-2)"
+else
+    fail "orionx-control-center maps to /opt/orionx/scripts/control_center/orionx-control-center" \
+         "W9-2: SCRIPT_MAP entry missing or wrong target for orionx-control-center"
+fi
+
 # Verify /usr/bin/ is the symlink target directory
 if [[ "$HOOK_CONTENT" == *"/usr/bin/"* ]]; then
     pass "PATH symlinks target /usr/bin/"
 else
     fail "PATH symlinks target /usr/bin/" \
          "Expected ln -sf ... /usr/bin/<script>"
+fi
+
+# W9-2: SCRIPT_MAP should have 10 entries (assert associative array has 10 keys).
+# Count lines matching the SCRIPT_MAP key=value pattern: ["name"]="path"
+SCRIPT_MAP_ENTRIES="$(grep -c '^\s*\["[^"]*"\]="[^"]*"' "$HOOK_FILE" 2>/dev/null || true)"
+if [[ "$SCRIPT_MAP_ENTRIES" -ge 10 ]]; then
+    pass "SCRIPT_MAP has >= 10 entries (W9-2: orionx-control-center is 10th entry)"
+else
+    fail "SCRIPT_MAP has >= 10 entries" \
+         "Found only $SCRIPT_MAP_ENTRIES — W9-2 requires orionx-control-center as the 10th entry"
 fi
 
 # ===========================================================================
@@ -251,6 +270,31 @@ if [[ "$LXTERM_FUNC_COUNT" -eq 0 ]]; then
 else
     fail "rc4: zero lxterminal references in functional lines" \
          "Found $LXTERM_FUNC_COUNT functional reference(s) — remove all non-comment lxterminal (not installed)"
+fi
+
+# W9-2: orionx-control-center.desktop created by the hook
+if [[ "$HOOK_CONTENT" == *"orionx-control-center.desktop"* ]]; then
+    pass "W9-2: orionx-control-center.desktop .desktop launcher present in hook"
+else
+    fail "W9-2: orionx-control-center.desktop .desktop launcher present in hook" \
+         "The 0700 hook must create /usr/share/applications/orionx-control-center.desktop"
+fi
+
+# W9-2: Control Center Exec uses /usr/bin/orionx-control-center (NO lxterminal — GTK app)
+if grep -q "Exec=/usr/bin/orionx-control-center" "$HOOK_FILE" 2>/dev/null; then
+    pass "W9-2: Control Center .desktop Exec=/usr/bin/orionx-control-center (DEC-PHASE9-006)"
+else
+    fail "W9-2: Control Center .desktop Exec=/usr/bin/orionx-control-center" \
+         "Control Center is a GTK app — Exec must be the direct binary, not xfce4-terminal wrapper"
+fi
+
+# W9-2: Control Center .desktop must NOT contain lxterminal in any Exec line
+# (functional check — DEC-PHASE9-006 invariant)
+if ! grep -v '^\s*#' "$HOOK_FILE" | grep "orionx-control-center" | grep -q "lxterminal"; then
+    pass "W9-2: orionx-control-center .desktop does NOT use lxterminal (DEC-PHASE9-006)"
+else
+    fail "W9-2: orionx-control-center .desktop does NOT use lxterminal" \
+         "Found lxterminal in functional orionx-control-center lines — must be direct GTK Exec"
 fi
 
 # rc4: one-click mesh launcher present (DEC-PHASE9-001)


### PR DESCRIPTION
Closes #45.

## What this slice ships

The cyberdeck UX baseline (rc5 candidate) per the operator-approved Phase 10
plan (recursive-foraging-blossom, DEC-PHASE10-005): Phase 9 W9-2 lands the
XFCE panel widgets + GTK "Orion-X Control Center" surface that Phase 10
Nebula AI slices plug into.

- **GTK Orion-X Control Center** (`scripts/control_center/`, Python 3 + GTK 3,
  stdlib + gi.repository only — no third-party deps). 6 sections render:
  Network, Mesh, Comms, Awareness, IR Tools, Nebula. Auto-Healing tab.
  The Nebula / Auto-Healing / Awareness sections are visible PLACEHOLDERS
  with explicit "lands in W10-X" markers — the discoverable plug-in
  surface for W10-1/-2/-3/-5/-6.
- **Real-today sections**: Network reads `nmcli` (NM from W9-1), Mesh
  shells to `orionx-mesh status`, Comms checks
  `matrix-synapse-orionx.service`, IR Tools launches the 6 existing
  operator tools (artifact-analyzer, storyboard-gen, pcap-analyzer,
  run-lynis, download-samples, toggle-theme) via xfce4-terminal — same
  pattern as W9-1's launchers (DEC-PHASE9-006).
- **XFCE panel widgets** (`scripts/control_center/widgets/`) driven by
  xfce4-genmon-plugin: net-status, mesh-status, plus W10-5 placeholders.
- **Package list extended**: python3-gi, gir1.2-gtk-3.0, gir1.2-glib-2.0,
  xfce4-genmon-plugin. Single package-set authority (DEC-PHASE9-016).
- **0700 hook**: 10th-13th symlink entries; new `.desktop` launcher
  `/usr/share/applications/orionx-control-center.desktop` (Exec=
  `/usr/bin/orionx-control-center`, not via terminal — GTK app launches
  windowed).
- **Autostart**: `/etc/xdg/autostart/orionx-control-center.desktop`
  shipped operator-opt-in (NoDisplay + X-GNOME-Autostart-enabled=false).
- **Tests**: `tests/unit/test_control_center.sh` (NEW, 67 assertions
  including DEC-PHASE9-019 future-annotations, DEC-PHASE9-020 ruff,
  no third-party imports, no shell=True, placeholder text contains
  W10-X markers). Extensions to test_build_iso.sh, test_orionx_setup_hook_unit.sh,
  test-iso-content-presence.sh (section 14), test-iso-hooks-applied.sh.

## Hard invariants honored
- DEC-PHASE9-019: every .py opens with `from __future__ import annotations`
- DEC-PHASE9-020: `ruff check scripts/control_center/` returns 0 errors
- DEC-PHASE9-006: zero functional `lxterminal` references
- DEC-PHASE9-016: single package-set / symlink / staging authorities
- DEC-PHASE9-012: integration test uses full unsquashfs extraction
- DEC-PHASE9-014: `|| true` on grep-count pipelines under set -e + pipefail
- DEC-PHASE10-005: Nebula + Auto-Healing visible placeholders ONLY — no
  runtime code (no ollama, no model, no MCP server, no playbooks)

## Local evidence (macOS host)
- 1189 unit tests pass, 0 failures across 29 test files
- `ruff check` clean
- `python3 -m py_compile` clean on every .py
- `python3 scripts/control_center/orionx-control-center --help` exits 0
- shellcheck + bash -n clean on edited integration tests
- Integration fake-build-log assertions: 20 PASS for the new W9-2 surface

## Definitive CI proof gates (this PR's QEMU Boot Test must reach)
- Build ISO in debian:bullseye container — confirm python3-gi,
  gir1.2-gtk-3.0, gir1.2-glib-2.0, xfce4-genmon-plugin install
- Verify Orion-X content present in ISO — new section 14 asserts
  /opt/orionx/scripts/control_center/orionx-control-center staged +
  executable, /usr/bin/orionx-control-center symlink, the .desktop
  launcher present, the 4 GTK/genmon packages installed in chroot dpkg
- Validate hooks executed — orionx-control-center.desktop created by 0700
- Run QEMU boot test — confirms image still boots after additions

## Scope
28 files; all within the W9-2 allowed scope (scripts/control_center/**,
package list, 0700 hook, includes.chroot/usr/share/applications/**,
includes.chroot/etc/xdg/autostart/**, tests/unit/**, the two integration
tests). MASTER_PLAN.md, release.yml, AppArmor, build-iso.sh untouched.
